### PR TITLE
Update workflow name for Java tooltips

### DIFF
--- a/.github/workflows/automate-tooltips.yaml
+++ b/.github/workflows/automate-tooltips.yaml
@@ -1,4 +1,4 @@
-name: Publish Kotlin docs
+name: Generate Java API tooltips
 
 permissions: write-all
 


### PR DESCRIPTION
### Description

The Java tooltips workflow name was incorrectly set to "Publish Kotlin docs"

### Fix

Modified the workflow name in _automate-tooltips.yaml_ to indicate that this is producing Java tooltips.