### PR TITLE
Fix/adfa-1592 Allow TooltipManager.py to work with Excel's XSLX-to-CSV exported output.

### DIFF
--- a/scripts/TooltipManager.py
+++ b/scripts/TooltipManager.py
@@ -97,7 +97,7 @@ def db_tooltips_to_csv(conn, csv_file_out):
             button_data.get('uri3')
         ])
 
-    with open(csv_file_out, 'w', newline='', encoding='utf-8-sig') as csvfile:
+    with open(csv_file_out, 'w', newline='', encoding='utf-8') as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(headers)
         writer.writerows(data_array)

--- a/scripts/TooltipManager.py
+++ b/scripts/TooltipManager.py
@@ -97,7 +97,7 @@ def db_tooltips_to_csv(conn, csv_file_out):
             button_data.get('uri3')
         ])
 
-    with open(csv_file_out, 'w', newline='', encoding='utf-8') as csvfile:
+    with open(csv_file_out, 'w', newline='', encoding='utf-8-sig') as csvfile:
         writer = csv.writer(csvfile)
         writer.writerow(headers)
         writer.writerows(data_array)
@@ -128,7 +128,7 @@ def csv_to_tooltips(conn, csv_file, name):
 
         # Read data from the CSV file and populate the tables.
         print(f"Reading data from {csv_file}...")
-        with open(csv_file, 'r', encoding='utf-8') as csvfile:
+        with open(csv_file, 'r', encoding='utf-8-sig') as csvfile:
             reader = csv.DictReader(csvfile)
             for row in reader:
                 # Insert data into the 'Tooltips' table first.


### PR DESCRIPTION
ADFA-1592 [https://appdevforall.atlassian.net/browse/ADFA-1592](https://appdevforall.atlassian.net/browse/ADFA-1592)

Allow TooltipManager.py to work with Excel's XSLX-to-CSV exported output.

------

To make life easier for now, an Excel user will choose the "UTF-8 CSV" export option to create their tooltip CSV file.

That output is actually utf-8-sig encoded, meaning it's utf-8 but there's an optional metadata character at the start that is meant to be processed by a reader that expects it.

In Excel's case, the character is actually there.

Since it's optional, just setting the reader encoding to "utf-8-sig" allows the script to handle Excel UTF-8 CSV output as well as CSV files in plain UTF-8 on Linux.

Elissa has successfully updated tooltips from Excel, and I've updated tooltips on Linux.