### PR TITLE
Fix tooltip search: match URIs by substring, not prefix (ADFA-4740 follow-up)

### DIFF
--- a/docdb-studio/docdb_studio.py
+++ b/docdb-studio/docdb_studio.py
@@ -142,11 +142,23 @@ def _build_like_pattern(term: str) -> str:
     return escaped.replace("*", "%") + "%"
 
 
+def _build_contains_pattern(term: str) -> str:
+    """Like `_build_like_pattern` but matches the term *anywhere* (substring),
+    not just at the start. Used for button URIs and descriptions, where the
+    useful part (a filename such as ``use.html``) is typically in the middle of
+    the value rather than at its start. ``*`` still works and metacharacters are
+    still escaped; e.g. ``'use.html' -> '%use.html%'``.
+    """
+    return "%" + _build_like_pattern(term)
+
+
 def _search_params(term: str) -> tuple[str, ...]:
-    # One pattern per placeholder in SEARCH_WHERE (tag, summary, detail,
-    # category, button uri, button description). All identical, so order is moot.
-    pattern = _build_like_pattern(term)
-    return (pattern,) * 6
+    # One pattern per placeholder in SEARCH_WHERE, in order: tag, summary,
+    # detail, category (prefix/"starts-with"), then button uri, description
+    # (substring/"contains", since URLs are searched by an interior fragment).
+    prefix = _build_like_pattern(term)
+    contains = _build_contains_pattern(term)
+    return (prefix, prefix, prefix, prefix, contains, contains)
 
 
 def get_total_count(db_path: Path, search_term: str | None = None) -> int:

--- a/docdb-studio/tests/test_tooltip_export.py
+++ b/docdb-studio/tests/test_tooltip_export.py
@@ -161,6 +161,18 @@ def test_search_matches_button_uri() -> None:
         db.unlink(missing_ok=True)
 
 
+def test_search_matches_uri_substring_without_wildcard() -> None:
+    """A bare term (no leading '*') still matches a URI fragment in the middle:
+    'rename.html' finds ide/refactor/rename.html even though the URI does not
+    start with it."""
+    db = _make_db()
+    try:
+        assert get_total_count(db, "refactor/rename") == 1
+        assert get_page(db, 50, 0, "refactor/rename")[0][2] == "rename"
+    finally:
+        db.unlink(missing_ok=True)
+
+
 def test_search_on_uri_does_not_duplicate_multibutton_tooltip() -> None:
     db = _make_db()
     try:

--- a/docdb-studio/tests/test_uri_validity.py
+++ b/docdb-studio/tests/test_uri_validity.py
@@ -319,8 +319,11 @@ def test_build_like_pattern_translates_user_wildcard_and_escapes_meta() -> None:
 
 
 def test_search_params_uses_anchored_pattern() -> None:
-    """Pin the tooltip-browse search semantics: each OR'd LIKE (tag, summary,
-    detail, category, button uri, button description) is anchored at the start
-    of its column, and there is one param per placeholder in SEARCH_WHERE."""
-    assert _search_params("foo") == ("foo%",) * 6
-    assert _search_params("*foo") == ("%foo%",) * 6
+    """Pin the tooltip-browse search semantics: tag/summary/detail/category are
+    anchored ("starts with"), while button uri/description match as a substring
+    ("contains"), since URLs are searched by an interior fragment. One param per
+    placeholder in SEARCH_WHERE, in that order."""
+    assert _search_params("foo") == ("foo%", "foo%", "foo%", "foo%", "%foo%", "%foo%")
+    # With a leading wildcard every column is already a substring match. The
+    # contains columns keep their extra leading '%' (harmless, still matches).
+    assert _search_params("*foo") == ("%foo%", "%foo%", "%foo%", "%foo%", "%%foo%", "%%foo%")


### PR DESCRIPTION
Follow-up to #19. That PR was squash-merged while a second commit was still in flight, so this one fix did not make it into `main`.

## Bug
Searching `use.html` did not find the tooltip whose button URI is `i/debugger-use.html#variables`. The table join was correct; the browse search is prefix-anchored ("starts with"), so `use.html` became `LIKE 'use.html%'` and missed the fragment because it sits in the middle of the URI.

## Fix
Search `tag`/`summary`/`detail`/`category` as prefixes (unchanged — right for hierarchical tags like `debug.edit.variable`), but match button `uri`/`description` as **substrings** via a new `_build_contains_pattern`. `*` still works everywhere.

## Verification
- Against the real ~380 MB DB: `use.html` → 30 matches incl. the reported tooltip 13; `debugger-use` and `variables` also find it; tag prefix search (`debug.edit`) still works.
- 177 tests pass (added a substring-URI test; updated the search-params assertion).