### PR TITLE
ADFA-5039: Convert kotlin-web-site docs to JSON

### DIFF
--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/README.md
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/README.md
@@ -45,10 +45,12 @@ python3 md_to_json.py <docs-root> <output-dir> <config> [--topics-subdir topics]
 ```
 
 Block types: `heading`, `paragraph`, `code`, `blockquote`, `list`, `table`,
-`image`, `hr`, `tabs`, `note`/`tip`/`warning`, `html` (raw passthrough). See
-the module docstring in [`md_to_json.py`](md_to_json.py) for full shapes and
+`hr`, `tabs`, `note`/`tip`/`warning`, `html` (raw passthrough). See the
+module docstring in [`md_to_json.py`](md_to_json.py) for full shapes and
 known limitations (nested tabs, `<include>` resolution, variable
-substitution).
+substitution). There is no standalone `image` block type - an image is
+always inline content inside whatever block contains it (typically
+`paragraph`), rendered straight into that block's own `html` string.
 
 A heading's `id` is `slugify()`'d from its text, unless the source line has
 an explicit `{id="..."}` (which overrides it directly). Cross-page links

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/README.md
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/README.md
@@ -1,0 +1,62 @@
+# Process Kotlin Website JSON
+
+Converts a `kotlin-web-site/docs` checkout (JetBrains Writerside-flavored
+Markdown) into the JSON block schema this project's templating engine
+renders.
+
+This PR (ADFA-5039) covers only [`md_to_json.py`](md_to_json.py) — the
+conversion step itself. Building the sidebar nav from `kr.tree`
+(`build_nav.py`), QA-ing the source tree for broken links/images
+(`find_missing_assets.py`), and loading any of this into `documentation.db`
+(`populate_db.py`, `insert_optimized_media.py`) are a separate ticket
+(ADFA-4739) and land in a later PR.
+
+## Requirements
+
+- Python 3.10+
+- `markdown-it-py` (now in the repo's root `requirements.txt`)
+
+## Usage
+
+```bash
+python3 md_to_json.py <docs-root> <output-dir> <config> [--topics-subdir topics]
+```
+
+- `<docs-root>` — a checkout of `kotlin-web-site/docs` (contains `v.list`, `topics/`, `images/`).
+- `<config>` — a JSON file with theming colors, e.g. [`config.json`](config.json):
+  ```json
+  {"broken-ext-link-color": "#cc0000", "menu-no-link-color": "#999999"}
+  ```
+
+`<output-dir>` ends up containing:
+- `topics/**/*.json` — one page per source `.md` file (schema below)
+- `theme.json` — the two theming colors, carried through from `<config>`
+- `images/` — copied straight from `<docs-root>/images/`
+
+### Page JSON schema
+
+```json
+{
+  "id": "enum-classes",
+  "sourceFile": "topics/enum-classes.md",
+  "title": "Enum classes",
+  "blocks": [ { "type": "heading", "level": 2, "id": "...", "html": "..." }, "..." ]
+}
+```
+
+Block types: `heading`, `paragraph`, `code`, `blockquote`, `list`, `table`,
+`image`, `hr`, `tabs`, `note`/`tip`/`warning`, `html` (raw passthrough). See
+the module docstring in [`md_to_json.py`](md_to_json.py) for full shapes and
+known limitations (nested tabs, `<include>` resolution, variable
+substitution).
+
+## Trying it out
+
+[`review_build_json.sh`](review_build_json.sh) is a throwaway helper for
+reviewers — it installs `markdown-it-py`, clones `kotlin-web-site`, and runs
+`md_to_json.py` against it so you can look at real output without any other
+setup. It's not part of the actual pipeline (that's ADFA-4739):
+
+```bash
+./review_build_json.sh
+```

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/README.md
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/README.md
@@ -19,7 +19,7 @@ conversion step itself. Building the sidebar nav from `kr.tree`
 ## Usage
 
 ```bash
-python3 md_to_json.py <docs-root> <output-dir> <config> [--topics-subdir topics]
+python3 md_to_json.py <docs-root> <output-dir> <config> [--topics-subdir topics] [--images-subdir images] [--allow-failures]
 ```
 
 - `<docs-root>` — a checkout of `kotlin-web-site/docs` (contains `v.list`, `topics/`, `images/`).
@@ -50,12 +50,22 @@ the module docstring in [`md_to_json.py`](md_to_json.py) for full shapes and
 known limitations (nested tabs, `<include>` resolution, variable
 substitution).
 
+A heading's `id` is `slugify()`'d from its text, unless the source line has
+an explicit `{id="..."}` (which overrides it directly). Cross-page links
+that carry a source `#anchor` are passed through verbatim rather than
+re-slugified, so a link and its target agree as long as both derive their id
+the same way; a hand-written `#anchor` that doesn't match either path (e.g.
+because Writerside's own anchor algorithm diverges from `slugify()` on
+headings with inline code or punctuation) will resolve to the right page but
+land on no anchor. Not currently detected - worth spot-checking if a page's
+in-page anchors stop scrolling to the right place.
+
 ## Trying it out
 
 [`review_build_json.sh`](review_build_json.sh) is a throwaway helper for
-reviewers — it installs `markdown-it-py`, clones `kotlin-web-site`, and runs
-`md_to_json.py` against it so you can look at real output without any other
-setup. It's not part of the actual pipeline (that's ADFA-4739):
+reviewers — it clones `kotlin-web-site` and runs `md_to_json.py` against it
+via `uv run` so you can look at real output without any other setup. It's
+not part of the actual pipeline (that's ADFA-4739):
 
 ```bash
 ./review_build_json.sh

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/config.json
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/config.json
@@ -1,0 +1,4 @@
+{
+  "broken-ext-link-color": "#cc0000",
+  "menu-no-link-color": "#999999"
+}

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/md_to_json.py
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/md_to_json.py
@@ -349,7 +349,8 @@ class Converter:
             # second one.
             existing = STYLE_ATTR_RE.search(tag)
             if existing:
-                return tag[:existing.start(1)] + existing.group(1) + " " + rule + tag[existing.end(1):]
+                sep = "" if not existing.group(1).strip() or existing.group(1).rstrip().endswith(";") else "; "
+                return tag[:existing.start(1)] + existing.group(1) + sep + " " + rule + tag[existing.end(1):]
             return tag[:-1] + f' style="{rule}">'
 
         return LINK_TAG_RE.sub(repl, html)
@@ -379,8 +380,8 @@ class Converter:
                     pos = m.end()
                     folded_any = True
                 if folded_any:
-                    remainder = content[pos:].strip()
-                    if remainder:
+                    remainder = content[pos:]
+                    if remainder.strip():
                         tok.content = remainder
                         result.append(tok)
                     continue
@@ -585,7 +586,7 @@ class Converter:
                     node = {"type": b["tag"], "attrs": b["attrs"], "blocks": []}
                     stack[-1]["blocks"].append(node)
                     stack.append(node)
-                elif stack[-1]["type"] == b["tag"]:
+                elif len(stack) > 1 and stack[-1]["type"] == b["tag"]:
                     stack.pop()
                 else:
                     # A closing marker that doesn't match the top of the
@@ -738,7 +739,7 @@ def load_config(config_path: Path) -> dict:
     for key in CONFIG_KEYS:
         if key not in config:
             print(f"warning: config {config_path} is missing {key!r}; that styling will be skipped", file=sys.stderr)
-        elif not COLOR_RE.match(config[key]):
+        elif not isinstance(config[key], str) or not COLOR_RE.match(config[key]):
             print(f"error: config {config_path} has an invalid {key!r} value {config[key]!r} "
                   f"(expected a hex color like \"#cc0000\" or a CSS color name)", file=sys.stderr)
             sys.exit(1)
@@ -809,6 +810,10 @@ def main():
     # forever, since nothing else here ever removes a file on its own.
     topics_out_dir = args.output_dir / args.topics_subdir
     if topics_out_dir.is_dir():
+        if topics_out_dir.resolve() == topics_dir.resolve():
+            print(f"error: output topics dir {topics_out_dir} is the source topics dir {topics_dir}",
+                  file=sys.stderr)
+            sys.exit(1)
         shutil.rmtree(topics_out_dir)
 
     count = 0

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/md_to_json.py
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/md_to_json.py
@@ -5,6 +5,7 @@ into a simple JSON block schema suitable for a templating engine.
 
 Usage:
     python3 md_to_json.py <docs-root> <output-dir> <config> [--topics-subdir topics]
+        [--images-subdir images] [--allow-failures]
 
 <docs-root> is the checkout of kotlin-web-site/docs (contains v.list, topics/, ...).
 One JSON file is written per input .md file, mirroring its relative path under
@@ -29,6 +30,9 @@ Output schema (one object per page):
 
 Block shapes:
   {"type": "heading", "level": 2, "id": "anonymous-classes", "html": "..."}
+    - "attrs" is present only if the heading's source line had a trailing
+      `{...}` attribute group (e.g. `## Title {id="custom-anchor"}`); an
+      explicit "id" in it overrides the auto-generated slug.
   {"type": "paragraph", "html": "..."}
   {"type": "code", "lang": "kotlin", "code": "...", "attrs": {"kotlin-runnable": "true"}}
   {"type": "blockquote", "attrs": {"style": "note"}, "blocks": [...]}
@@ -66,9 +70,17 @@ Known limitations (fine for a first pass, worth revisiting before production use
   - A handful of images/ filenames collide across subdirectories (leftover
     duplicates in the source tree); resolution keeps the first match in sorted
     order and prints a warning rather than guessing which one is "correct".
+  - A heading's id is slugify()'d from its text unless the source overrides
+    it with a trailing "{id=...}". A hand-written #anchor that was authored
+    against Writerside's own anchor algorithm rather than either of those
+    could still resolve to the right page but land on no anchor, if the two
+    algorithms diverge on a case not yet seen in the corpus (inline code or
+    punctuation in the heading, duplicate heading text) - not currently
+    detected.
 """
 import argparse
 import json
+import os
 import re
 import shutil
 import sys
@@ -80,22 +92,49 @@ from markdown_it.token import Token
 
 TITLE_RE = re.compile(r"^\[//\]:\s*#\s*\(title:\s*(.*?)\)\s*$", re.MULTILINE)
 ATTR_LINE_RE = re.compile(r"^\{(.*)\}$")
-ATTR_PAIR_RE = re.compile(r'([\w-]+)=(?:"([^"]*)"|(\S+))')
-TAG_RE = re.compile(r"^<(/?)(tabs|tab|note|tip|warning)([^>]*)/?>$", re.I)
+TRAILING_ATTR_GROUPS_RE = re.compile(r"\s*((?:\{[^{}]*\})+)\s*$")
+
+# No leading "^": matched via .match(content, pos) below, which already
+# anchors at pos - unlike search(), match() never scans forward - but "^"
+# itself always means the absolute start of the *string*, not of pos, so
+# keeping it here would silently stop the pos-advancing loop after the
+# first brace group on every second-and-later iteration.
+IMAGE_ATTR_GROUP_RE = re.compile(r"\{([^{}]*)\}")
+ATTR_PAIR_RE = re.compile(r'([\w-]+)\s*=\s*(?:"([^"]*)"|(\S+))')
 VAR_RE = re.compile(r"%([\w.-]+)%")
 MD_LINK_RE = re.compile(r"^([\w.-]+)\.md(#.*)?$")
 EXTERNAL_HREF_RE = re.compile(r"^(?:[a-zA-Z][a-zA-Z0-9+.-]*:)?//|^mailto:", re.I)
 LINK_TAG_RE = re.compile(r'<a\b[^>]*\bhref="([^"]*)"[^>]*>')
+STYLE_ATTR_RE = re.compile(r'\bstyle="([^"]*)"')
+IMG_TAG_RE = re.compile(r"<img\b[^>]*>", re.I)
+IMG_SRC_RE = re.compile(r'src="([^"]*)"')
+COLOR_RE = re.compile(r"^#[0-9a-fA-F]{3,8}$|^[a-zA-Z]+$")
 
+# TAG_RE is built from this set (rather than hardcoding the same five names
+# twice) so the two can't silently diverge. The (?![\w-]) after the
+# alternation is load-bearing: without it, "tab" matches as a prefix of
+# "table", consuming "<table>" as tag "tab" with attrs "le".
 CONTAINER_TAGS = {"tabs", "tab", "note", "tip", "warning"}
+TAG_RE = re.compile(r"^<(/?)(" + "|".join(CONTAINER_TAGS) + r")(?![\w-])([^>]*)/?>$", re.I)
 
 
 def build_topic_index(topics_dir: Path) -> dict:
-    """Bare filename stem (e.g. "enum-classes") -> page id (e.g. "kotlin-tour/enum-classes")."""
+    """Bare filename stem (e.g. "enum-classes") -> page id (e.g. "kotlin-tour/enum-classes").
+
+    Mirrors build_image_index's collision handling: a stem that exists more
+    than once under topics_dir keeps its first (sorted) page id and prints a
+    warning naming the others, rather than resolving to whichever sorts
+    first with no diagnostic at all."""
     index = {}
+    candidates = {}
     for md_path in sorted(topics_dir.rglob("*.md")):
-        page_id = str(md_path.relative_to(topics_dir).with_suffix("")).replace("\\", "/")
+        page_id = md_path.relative_to(topics_dir).with_suffix("").as_posix()
+        candidates.setdefault(md_path.stem, []).append(page_id)
         index.setdefault(md_path.stem, page_id)
+    for stem, ids in sorted(candidates.items()):
+        if len(ids) > 1:
+            print(f"warning: ambiguous topic filename {stem!r}: "
+                  f"using {ids[0]}.md, ignoring {', '.join(i + '.md' for i in ids[1:])}", file=sys.stderr)
     return index
 
 
@@ -137,9 +176,14 @@ def substitute_vars(text: str, variables: dict) -> str:
 
 
 def parse_attrs(attr_str: str) -> dict:
+    """name="quoted value" or name=bare -> {"name": "quoted value"/"bare"},
+    decided per pair. findall() coerces a non-participating group to "" (not
+    None), and exactly one of quoted/bare participates per match, so the
+    other is always "" - `quoted or bare` picks whichever one actually
+    matched, including a genuinely empty quoted value ("" or "" -> "")."""
     attrs = {}
     for name, quoted, bare in ATTR_PAIR_RE.findall(attr_str or ""):
-        attrs[name] = quoted if quoted != "" or '="' in (attr_str or "") else bare
+        attrs[name] = quoted or bare
     return attrs
 
 
@@ -202,6 +246,23 @@ class Converter:
         # resolution logic (rather than re-parsing links with regexes) by
         # running convert_file over every page and reading this list back.
         self.warnings = []
+        # Reset per file in convert_file - two headings with the same text
+        # on the same page would otherwise share a slug, so an anchor to the
+        # second one lands on the first.
+        self.seen_heading_ids = set()
+
+    def unique_heading_id(self, text: str) -> str:
+        """slugify(text), de-duped against every other heading id already
+        seen on this page - resolve_href points at these ids verbatim (via
+        the source's own #anchor), so two headings sharing a slug would
+        make any link to the second one land on the first instead."""
+        base = slug = slugify(text)
+        n = 2
+        while slug in self.seen_heading_ids:
+            slug = f"{base}-{n}"
+            n += 1
+        self.seen_heading_ids.add(slug)
+        return slug
 
     def resolve_href(self, href: str):
         """"other-page.md#anchor" -> "/<page-id>.html#anchor", or None to leave href untouched."""
@@ -247,7 +308,11 @@ class Converter:
             return f'src="{new_src}"' if new_src is not None else m.group(0)
 
         html = re.sub(r'href="([^"]*)"', href_repl, html)
-        html = re.sub(r'src="([^"]*)"', src_repl, html)
+        # Scoped to <img ...> tags specifically - a bare src="..." regex
+        # would also rewrite <script src=...>/<iframe src=...>, running the
+        # image resolver against filenames that were never images and
+        # producing false "image not found" warnings for them.
+        html = IMG_TAG_RE.sub(lambda m: IMG_SRC_RE.sub(src_repl, m.group(0)), html)
         return self.style_broken_and_external_links(html)
 
     def classify_href(self, href: str):
@@ -275,27 +340,76 @@ class Converter:
             tag = m.group(0)
             if self.classify_href(m.group(1)) is None:
                 return tag
-            return tag[:-1] + f' style="color: {self.broken_ext_link_color};">'
+            rule = f"color: {self.broken_ext_link_color};"
+            # An <a> that already carries a style= (rare, but Writerside's
+            # raw HTML passthrough allows it) would otherwise end up with
+            # two style attributes - HTML5 keeps only the first, so the
+            # color being added here would be the one silently ignored.
+            # Merge into the existing attribute instead of appending a
+            # second one.
+            existing = STYLE_ATTR_RE.search(tag)
+            if existing:
+                return tag[:existing.start(1)] + existing.group(1) + " " + rule + tag[existing.end(1):]
+            return tag[:-1] + f' style="{rule}">'
 
         return LINK_TAG_RE.sub(repl, html)
 
     def fold_image_attrs(self, tokens) -> list:
-        """Folds a `{...}` attribute-text token immediately following an
-        image (e.g. `![alt](x.png){width="500"}` - CommonMark has no syntax
-        for this, so it otherwise tokenizes as a literal "{width=..}" text
-        run right after the image) into that image's own HTML attributes
-        instead of leaving it as visible text."""
+        """Folds one or more `{...}` attribute-text groups immediately
+        following an image (e.g. `![alt](x.png){width="500"}{type="joined"}`
+        - CommonMark has no syntax for this, so it otherwise tokenizes as a
+        literal "{width=..}{type=..}" text run right after the image) into
+        that image's own HTML attributes instead of leaving it as visible
+        text. Only the leading `{...}` group(s) are consumed - anything
+        after them (a second attribute group is fine, but so is unrelated
+        prose the author just happened to write right after the image) is
+        kept as ordinary visible text rather than silently discarded along
+        with the attribute groups."""
         result = []
         for tok in tokens:
             if tok.type == "text" and result and result[-1].type == "image":
-                m = ATTR_LINE_RE.match(tok.content.strip())
-                if m:
+                content = tok.content.strip()
+                pos = 0
+                folded_any = False
+                while True:
+                    m = IMAGE_ATTR_GROUP_RE.match(content, pos)
+                    if not m:
+                        break
                     result[-1].attrs.update(parse_attrs(m.group(1)))
+                    pos = m.end()
+                    folded_any = True
+                if folded_any:
+                    remainder = content[pos:].strip()
+                    if remainder:
+                        tok.content = remainder
+                        result.append(tok)
                     continue
             if tok.children:
                 tok.children = self.fold_image_attrs(tok.children)
             result.append(tok)
         return result
+
+    def extract_trailing_attrs(self, children) -> dict:
+        """Strips trailing `{...}` attribute group(s) off the last text
+        child (if any) and returns the parsed attrs - the same Writerside
+        `{key="value"}` convention fold_image_attrs handles for images, but
+        written after a heading's own text instead (e.g.
+        `## Enum classes {id="custom-anchor"}`). Found by running the real
+        converter against the live kotlin-web-site corpus: unlike the image
+        case, this one was landing as visible garbage text at the end of
+        the rendered heading with no attribute handling at all."""
+        if not children or children[-1].type != "text":
+            return {}
+        m = TRAILING_ATTR_GROUPS_RE.search(children[-1].content)
+        if not m:
+            return {}
+        attrs = {}
+        for group in re.findall(r"\{([^{}]*)\}", m.group(1)):
+            attrs.update(parse_attrs(group))
+        if not attrs:
+            return {}
+        children[-1].content = children[-1].content[: m.start()]
+        return attrs
 
     def render_inline(self, inline_token: Token) -> str:
         children = self.fold_image_attrs(inline_token.children)
@@ -329,13 +443,37 @@ class Converter:
         if ttype == "heading_open":
             inline = node.children[0].token
             level = int(t.tag[1:])
-            text = inline.content
-            return {
+            # Must run before render_inline (which also folds image attrs
+            # off inline.children) so a trailing "{id=...}" doesn't survive
+            # into the rendered heading text as literal garbage, and so an
+            # explicit id, if given, can override the auto-generated slug -
+            # that's the actual point of Writerside authors writing one.
+            heading_attrs = self.extract_trailing_attrs(inline.children)
+            if heading_attrs.get("id"):
+                # An explicit id is an intentional, presumably-stable anchor
+                # - registered so a *later* auto-slugified heading won't be
+                # renamed into colliding with it, but not itself renamed
+                # even if two headings happen to specify the same one.
+                heading_id = heading_attrs["id"]
+                self.seen_heading_ids.add(heading_id)
+            else:
+                # heading_attrs being non-empty (just with no "id" key, e.g.
+                # only "completion-point") still means a suffix was found
+                # and stripped off inline.children - inline.content itself
+                # is a separate cached string on the parent token, so it
+                # needs the same suffix removed before it's used for the
+                # slug, or the leftover "{...}" text would still corrupt it.
+                clean_text = TRAILING_ATTR_GROUPS_RE.sub("", inline.content) if heading_attrs else inline.content
+                heading_id = self.unique_heading_id(clean_text)
+            block = {
                 "type": "heading",
                 "level": level,
-                "id": slugify(text),
+                "id": heading_id,
                 "html": self.render_inline(inline),
             }
+            if heading_attrs:
+                block["attrs"] = heading_attrs
+            return block
 
         if ttype == "fence":
             return {
@@ -424,14 +562,20 @@ class Converter:
             if b["type"] == "paragraph":
                 raw = b.pop("_raw", "").strip()
                 m = ATTR_LINE_RE.match(raw)
-                if m and merged:
-                    merged[-1].setdefault("attrs", {}).update(parse_attrs(m.group(1)))
-                    continue
+                if m:
+                    parsed = parse_attrs(m.group(1))
+                    # Only fold (and drop the paragraph) when something was
+                    # actually recovered - a `{...}`-shaped paragraph that
+                    # parses to no attrs (e.g. `{ a.length }`, or a real
+                    # attr line that ATTR_PAIR_RE just doesn't match) is
+                    # still real page content, not a decoration to discard.
+                    if parsed and merged:
+                        merged[-1].setdefault("attrs", {}).update(parsed)
+                        continue
             merged.append(b)
         return merged
 
-    @staticmethod
-    def group_containers(blocks: list) -> list:
+    def group_containers(self, blocks: list) -> list:
         """Turn <tabs>/<tab>/<note>/<tip>/<warning> tag_marker pairs into nested blocks."""
         root: dict = {"blocks": []}
         stack = [root]
@@ -441,8 +585,28 @@ class Converter:
                     node = {"type": b["tag"], "attrs": b["attrs"], "blocks": []}
                     stack[-1]["blocks"].append(node)
                     stack.append(node)
-                elif len(stack) > 1 and stack[-1]["type"] == b["tag"]:
+                elif stack[-1]["type"] == b["tag"]:
                     stack.pop()
+                else:
+                    # A closing marker that doesn't match the top of the
+                    # stack used to be discarded outright, leaving the
+                    # wrong frame open - everything after it then landed
+                    # inside a container it was never written to be part
+                    # of. This always indicates malformed source (a missing
+                    # closer somewhere), so it's always worth a warning -
+                    # pop back to the nearest open frame of the same tag
+                    # anywhere on the stack when one exists (closing
+                    # whatever was left open in between), or just ignore the
+                    # marker if it doesn't.
+                    print(f"warning: unmatched </{b['tag']}> in {self.current_source!r}", file=sys.stderr)
+                    self.warnings.append(
+                        {"kind": "tag", "source": self.current_source, "reference": f"</{b['tag']}>"}
+                    )
+                    match_depth = next(
+                        (i for i in range(len(stack) - 1, 0, -1) if stack[i]["type"] == b["tag"]), None
+                    )
+                    if match_depth is not None:
+                        del stack[match_depth:]
                 continue
             stack[-1]["blocks"].append(b)
 
@@ -468,8 +632,13 @@ class Converter:
             children = Converter._finalize_list(b["blocks"])
             tab_children = [c for c in children if c.get("type") == "tab"]
             if tab_children:
-                # Well-formed <tabs><tab>...</tab>...</tabs>.
-                return {
+                # Well-formed <tabs><tab>...</tab>...</tabs>. Any sibling
+                # that isn't itself a <tab> (intro/trailing prose written
+                # inside the <tabs> block) doesn't belong inside any one
+                # tab, so splice it back in at the tabs block's own
+                # position instead of dropping it - only the <tab> children
+                # feed the "tabs" list below.
+                tabs_block = {
                     "type": "tabs",
                     "attrs": b["attrs"],
                     "tabs": [
@@ -477,6 +646,18 @@ class Converter:
                         for c in tab_children
                     ],
                 }
+                if len(tab_children) == len(children):
+                    return tabs_block
+                result = []
+                inserted = False
+                for c in children:
+                    if c.get("type") == "tab":
+                        if not inserted:
+                            result.append(tabs_block)
+                            inserted = True
+                        continue
+                    result.append(c)
+                return result
             if len(children) >= 2 and all(c.get("type") == "code" for c in children):
                 # Bare <tabs> wrapping only fenced code blocks with no <tab>
                 # tags at all (seen in some compatibility guide pages, e.g.
@@ -512,6 +693,7 @@ class Converter:
 
     def convert_file(self, path: Path, page_id: str, source_rel: str) -> dict:
         self.current_source = source_rel
+        self.seen_heading_ids = set()
         raw = path.read_text(encoding="utf-8")
         # Substitute %variables% in the raw source, before markdown-it ever
         # sees it. Doing this post-render instead would (a) miss the title,
@@ -545,12 +727,34 @@ def load_config(config_path: Path) -> dict:
     """Loads the {"broken-ext-link-color": ..., "menu-no-link-color": ...}
     theming config. Missing keys just disable that particular styling (a
     warning is printed) rather than being a hard error, since neither is
-    required for the JSON conversion itself to be correct."""
+    required for the JSON conversion itself to be correct. A present key
+    that isn't a plausible CSS color, however, IS a hard error:
+    broken-ext-link-color is interpolated directly into a `style="color:
+    ...;"` HTML attribute (see style_broken_and_external_links), so an
+    unvalidated value is a markup-injection hole - config.json is
+    repo-controlled today, not attacker-reachable, but validating here means
+    that stays true if it ever grows a CI override."""
     config = json.loads(config_path.read_text(encoding="utf-8"))
     for key in CONFIG_KEYS:
         if key not in config:
             print(f"warning: config {config_path} is missing {key!r}; that styling will be skipped", file=sys.stderr)
+        elif not COLOR_RE.match(config[key]):
+            print(f"error: config {config_path} has an invalid {key!r} value {config[key]!r} "
+                  f"(expected a hex color like \"#cc0000\" or a CSS color name)", file=sys.stderr)
+            sys.exit(1)
     return config
+
+
+def _copy_if_changed(src, dst, *, follow_symlinks=True):
+    """shutil.copytree copy_function that skips a file whose size and mtime
+    already match the destination - kotlin-web-site's images/ is roughly
+    1,800 files / 90MB, and copytree(dirs_exist_ok=True) otherwise re-copies
+    every one of them on every run even when only a single topic changed."""
+    if os.path.exists(dst):
+        s_stat, d_stat = os.stat(src), os.stat(dst)
+        if s_stat.st_size == d_stat.st_size and int(s_stat.st_mtime) == int(d_stat.st_mtime):
+            return dst
+    return shutil.copy2(src, dst, follow_symlinks=follow_symlinks)
 
 
 def main():
@@ -561,6 +765,9 @@ def main():
                          help='Path to a JSON config with "broken-ext-link-color" and "menu-no-link-color"')
     parser.add_argument("--topics-subdir", default="topics", help="Subdirectory of docs_root holding .md files")
     parser.add_argument("--images-subdir", default="images", help="Subdirectory of docs_root holding image files")
+    parser.add_argument("--allow-failures", action="store_true",
+                         help="Exit 0 even if some files failed to convert (default: exit 1 if any did, "
+                              "so a CI step calling this can tell a partial run from a complete one)")
     args = parser.parse_args()
 
     docs_root: Path = args.docs_root
@@ -576,7 +783,7 @@ def main():
     config = load_config(args.config)
     variables = load_variables(docs_root)
     topic_index = build_topic_index(topics_dir)
-    image_index, _image_collisions = build_image_index(images_dir)
+    image_index, _image_collisions = build_image_index(images_dir)  # collisions warning already printed inside
     md = make_markdown_it()
     converter = Converter(md, variables, topic_index, image_index,
                            broken_ext_link_color=config.get("broken-ext-link-color"))
@@ -593,19 +800,31 @@ def main():
     )
 
     if images_dir.is_dir():
-        shutil.copytree(images_dir, args.output_dir / "images", dirs_exist_ok=True)
+        shutil.copytree(images_dir, args.output_dir / "images", dirs_exist_ok=True, copy_function=_copy_if_changed)
     else:
         print(f"warning: {images_dir} not found; image references will 404", file=sys.stderr)
 
+    # Clear out whatever a previous run wrote here first - otherwise a topic
+    # deleted upstream since then keeps its stale JSON (and keeps shipping)
+    # forever, since nothing else here ever removes a file on its own.
+    topics_out_dir = args.output_dir / args.topics_subdir
+    if topics_out_dir.is_dir():
+        shutil.rmtree(topics_out_dir)
+
     count = 0
+    failed = 0
     for md_path in md_files:
         rel = md_path.relative_to(topics_dir)
-        page_id = str(rel.with_suffix(""))
-        source_rel = str(Path(args.topics_subdir) / rel)
+        # .as_posix(), not str() - build_topic_index resolves cross-page
+        # links through the same forward-slashed ids, so an OS-native
+        # separator here would make the two disagree on Windows.
+        page_id = rel.with_suffix("").as_posix()
+        source_rel = f"{args.topics_subdir}/{rel.as_posix()}"
         try:
             page = converter.convert_file(md_path, page_id, source_rel)
         except Exception as exc:  # noqa: BLE001 - surface which file broke
             print(f"error converting {md_path}: {exc}", file=sys.stderr)
+            failed += 1
             continue
         out_path = args.output_dir / args.topics_subdir / rel.with_suffix(".json")
         out_path.parent.mkdir(parents=True, exist_ok=True)
@@ -613,6 +832,9 @@ def main():
         count += 1
 
     print(f"Converted {count}/{len(md_files)} files into {args.output_dir}")
+    if failed and not args.allow_failures:
+        print(f"error: {failed} file(s) failed to convert (pass --allow-failures to tolerate this)", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/md_to_json.py
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/md_to_json.py
@@ -1,0 +1,619 @@
+#!/usr/bin/env python3
+"""
+Converts JetBrains Writerside-flavored Markdown (as used by kotlin-web-site/docs)
+into a simple JSON block schema suitable for a templating engine.
+
+Usage:
+    python3 md_to_json.py <docs-root> <output-dir> <config> [--topics-subdir topics]
+
+<docs-root> is the checkout of kotlin-web-site/docs (contains v.list, topics/, ...).
+One JSON file is written per input .md file, mirroring its relative path under
+<topics-subdir>.
+
+<config> is a JSON file with:
+  {"broken-ext-link-color": "#cc0000", "menu-no-link-color": "#999999"}
+"broken-ext-link-color" colors <a> tags in the rendered content that are
+either off-site (any http(s)/mailto: link) or a same-tree ".md" reference
+that doesn't resolve to a real page. "menu-no-link-color" isn't used here -
+it's carried through to <output-dir>/theme.json for build_nav.py (which
+builds the sidebar from kr.tree, a separate input this script doesn't read)
+to pick up.
+
+Output schema (one object per page):
+{
+  "id": "enum-classes",
+  "sourceFile": "topics/enum-classes.md",
+  "title": "Enum classes",
+  "blocks": [ <block>, ... ]
+}
+
+Block shapes:
+  {"type": "heading", "level": 2, "id": "anonymous-classes", "html": "..."}
+  {"type": "paragraph", "html": "..."}
+  {"type": "code", "lang": "kotlin", "code": "...", "attrs": {"kotlin-runnable": "true"}}
+  {"type": "blockquote", "attrs": {"style": "note"}, "blocks": [...]}
+  {"type": "list", "ordered": false, "items": [{"blocks": [...]}]}
+  {"type": "table", "headers": ["a", "b"], "rows": [["1", "2"]]}
+  {"type": "image", "src": "...", "alt": "..."}
+  {"type": "hr"}
+  {"type": "tabs", "attrs": {"group": "build-system"},
+   "tabs": [{"title": "Gradle", "attrs": {"group-key": "gradle"}, "blocks": [...]}]}
+  {"type": "html", "html": "<raw passthrough for anything unrecognized>"}
+
+Cross-page links (`[text](other-page.md#anchor)`) and images (`![alt](foo.png)`)
+use Writerside's bare-filename convention - the referenced file is looked up
+by name anywhere under <topics-subdir>/ (links) or images/ (images), the same
+way kr.tree's topic="..." references are resolved. Rendered HTML rewrites
+these to root-relative URLs that only resolve once this JSON has been passed
+through templates/page.peb and rendered by RenderDocs: links become
+"/<page-id>.html#anchor", and images become "/images/<path-within-images>".
+The images/ directory itself is copied to <output-dir>/images/ so the
+resolved paths have something to point at.
+
+Known limitations (fine for a first pass, worth revisiting before production use):
+  - <tabs>/<tab> grouping and attribute-line merging (the "{...}" line after a
+    fence/blockquote) only happen at the top level of a page and inside list
+    items/blockquotes/table cells one level deep; deeply nested tabs-in-tabs
+    are not handled.
+  - <note>/<tip>/<warning> admonitions are recognized as block-level tags. The
+    inline, single-line form seen inside HTML tables (e.g. roadmap.md) is passed
+    through as raw "html" blocks instead of being unpacked, since those pages
+    are basically hand-written HTML tables rather than prose.
+  - <include> elements are passed through as raw "html" blocks; resolving them
+    to the referenced snippet is not implemented.
+  - %variables% (defined in v.list) are substituted textually in rendered HTML
+    and code, using simple %name% -> value replacement.
+  - A handful of images/ filenames collide across subdirectories (leftover
+    duplicates in the source tree); resolution keeps the first match in sorted
+    order and prints a warning rather than guessing which one is "correct".
+"""
+import argparse
+import json
+import re
+import shutil
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from markdown_it import MarkdownIt
+from markdown_it.token import Token
+
+TITLE_RE = re.compile(r"^\[//\]:\s*#\s*\(title:\s*(.*?)\)\s*$", re.MULTILINE)
+ATTR_LINE_RE = re.compile(r"^\{(.*)\}$")
+ATTR_PAIR_RE = re.compile(r'([\w-]+)=(?:"([^"]*)"|(\S+))')
+TAG_RE = re.compile(r"^<(/?)(tabs|tab|note|tip|warning)([^>]*)/?>$", re.I)
+VAR_RE = re.compile(r"%([\w.-]+)%")
+MD_LINK_RE = re.compile(r"^([\w.-]+)\.md(#.*)?$")
+EXTERNAL_HREF_RE = re.compile(r"^(?:[a-zA-Z][a-zA-Z0-9+.-]*:)?//|^mailto:", re.I)
+LINK_TAG_RE = re.compile(r'<a\b[^>]*\bhref="([^"]*)"[^>]*>')
+
+CONTAINER_TAGS = {"tabs", "tab", "note", "tip", "warning"}
+
+
+def build_topic_index(topics_dir: Path) -> dict:
+    """Bare filename stem (e.g. "enum-classes") -> page id (e.g. "kotlin-tour/enum-classes")."""
+    index = {}
+    for md_path in sorted(topics_dir.rglob("*.md")):
+        page_id = str(md_path.relative_to(topics_dir).with_suffix("")).replace("\\", "/")
+        index.setdefault(md_path.stem, page_id)
+    return index
+
+
+def build_image_index(images_dir: Path):
+    """Bare filename (e.g. "mascot-main.png") -> path relative to images_dir.
+
+    Returns (index, collisions), where collisions is a list of
+    (filename, [candidate relative paths]) for filenames that exist in more
+    than one place under images_dir - index keeps the first (sorted) one."""
+    index = {}
+    candidates = {}
+    if not images_dir.is_dir():
+        return index, []
+    for img_path in sorted(images_dir.rglob("*")):
+        if not img_path.is_file():
+            continue
+        rel = img_path.relative_to(images_dir).as_posix()
+        candidates.setdefault(img_path.name, []).append(rel)
+        index.setdefault(img_path.name, rel)
+    collisions = [(name, rels) for name, rels in sorted(candidates.items()) if len(rels) > 1]
+    for name, rels in collisions:
+        print(f"warning: ambiguous image filename {name!r}: "
+              f"using images/{rels[0]}, ignoring {', '.join('images/' + r for r in rels[1:])}", file=sys.stderr)
+    return index, collisions
+
+
+def load_variables(docs_root: Path) -> dict:
+    v_list = docs_root / "v.list"
+    if not v_list.exists():
+        return {}
+    tree = ET.parse(v_list)
+    return {el.get("name"): el.get("value") for el in tree.getroot().findall("var")}
+
+
+def substitute_vars(text: str, variables: dict) -> str:
+    if not text:
+        return text
+    return VAR_RE.sub(lambda m: variables.get(m.group(1), m.group(0)), text)
+
+
+def parse_attrs(attr_str: str) -> dict:
+    attrs = {}
+    for name, quoted, bare in ATTR_PAIR_RE.findall(attr_str or ""):
+        attrs[name] = quoted if quoted != "" or '="' in (attr_str or "") else bare
+    return attrs
+
+
+def extract_title(raw_text: str):
+    m = TITLE_RE.search(raw_text)
+    if not m:
+        return None, raw_text
+    title = m.group(1).strip()
+    remaining = raw_text[: m.start()] + raw_text[m.end():]
+    return title, remaining
+
+
+def slugify(text: str) -> str:
+    slug = re.sub(r"[^\w\s-]", "", text.lower()).strip()
+    return re.sub(r"[\s_]+", "-", slug)
+
+
+class Node:
+    """Generic open/close tree built from markdown-it's flat token stream."""
+
+    __slots__ = ("token", "children")
+
+    def __init__(self, token: Token):
+        self.token = token
+        self.children = []
+
+
+def build_tree(tokens) -> list:
+    root = []
+    stack = [root]
+    for tok in tokens:
+        if tok.nesting == 1:
+            node = Node(tok)
+            stack[-1].append(node)
+            stack.append(node.children)
+        elif tok.nesting == -1:
+            stack.pop()
+        else:
+            stack[-1].append(Node(tok))
+    return root
+
+
+class Converter:
+    def __init__(self, md: MarkdownIt, variables: dict, topic_index: dict = None, image_index: dict = None,
+                 broken_ext_link_color: str = None, image_url_prefix: str = "/images/"):
+        self.md = md
+        self.variables = variables
+        self.topic_index = topic_index or {}
+        self.image_index = image_index or {}
+        self.broken_ext_link_color = broken_ext_link_color
+        # Overridable so a different deployment target (e.g. populate_db.py's
+        # database-backed site, which serves images from "/k/html/images/"
+        # rather than a bare "/images/") can retarget every image src without
+        # a separate rewrite pass - resolve_image_src just uses this prefix
+        # directly.
+        self.image_url_prefix = image_url_prefix
+        self.current_source = None
+        # Populated as a side effect of resolve_href/resolve_image_src failing
+        # to resolve a reference; find_missing_assets.py reuses this same
+        # resolution logic (rather than re-parsing links with regexes) by
+        # running convert_file over every page and reading this list back.
+        self.warnings = []
+
+    def resolve_href(self, href: str):
+        """"other-page.md#anchor" -> "/<page-id>.html#anchor", or None to leave href untouched."""
+        m = MD_LINK_RE.match(href or "")
+        if not m:
+            return None
+        stem, anchor = m.groups()
+        page_id = self.topic_index.get(stem)
+        if page_id is None:
+            print(f"warning: link to unknown topic {href!r}", file=sys.stderr)
+            self.warnings.append({"kind": "link", "source": self.current_source, "reference": href})
+            return None
+        return f"/{page_id}.html{anchor or ''}"
+
+    def resolve_image_src(self, src: str):
+        """"foo.png" -> "<image_url_prefix><path-within-images>", or None to leave src untouched."""
+        if not src or "://" in src or src.startswith("/") or "/" in src:
+            return None
+        rel = self.image_index.get(src)
+        if rel is None:
+            print(f"warning: image not found: {src!r}", file=sys.stderr)
+            self.warnings.append({"kind": "image", "source": self.current_source, "reference": src})
+            return None
+        return f"{self.image_url_prefix}{rel}"
+
+    def rewrite_urls(self, html: str) -> str:
+        """Rewrites every href="...md" / src="foo.png" attribute found in a
+        blob of rendered/raw HTML. Applied to markdown-rendered HTML *and* to
+        Writerside's raw <a>/<img> passthrough HTML (which markdown-it never
+        tokenizes as links/images at all, so token-level rewriting alone
+        would miss it); resolve_href/resolve_image_src already leave anything
+        that isn't a bare same-tree ".md"/image reference untouched, so this
+        is safe to run unconditionally on any HTML string."""
+        if not html:
+            return html
+
+        def href_repl(m):
+            new_href = self.resolve_href(m.group(1))
+            return f'href="{new_href}"' if new_href is not None else m.group(0)
+
+        def src_repl(m):
+            new_src = self.resolve_image_src(m.group(1))
+            return f'src="{new_src}"' if new_src is not None else m.group(0)
+
+        html = re.sub(r'href="([^"]*)"', href_repl, html)
+        html = re.sub(r'src="([^"]*)"', src_repl, html)
+        return self.style_broken_and_external_links(html)
+
+    def classify_href(self, href: str):
+        """Classifies an *already rewritten* href: 'external' for off-site
+        (or mailto:) links, 'broken' for a same-tree ".md" reference that's
+        still literally "foo.md" because resolve_href couldn't find it, or
+        None for anything that resolved fine (now "/id.html...") or is a
+        same-page "#anchor" link."""
+        if not href or href.startswith("#"):
+            return None
+        if EXTERNAL_HREF_RE.match(href):
+            return "external"
+        if MD_LINK_RE.match(href):
+            return "broken"
+        return None
+
+    def style_broken_and_external_links(self, html: str) -> str:
+        """Colors broken and off-site <a> tags with --broken-ext-link-color
+        (from the config passed on the command line) so readers can tell at a
+        glance which links leave this site or don't go anywhere at all."""
+        if not self.broken_ext_link_color:
+            return html
+
+        def repl(m):
+            tag = m.group(0)
+            if self.classify_href(m.group(1)) is None:
+                return tag
+            return tag[:-1] + f' style="color: {self.broken_ext_link_color};">'
+
+        return LINK_TAG_RE.sub(repl, html)
+
+    def fold_image_attrs(self, tokens) -> list:
+        """Folds a `{...}` attribute-text token immediately following an
+        image (e.g. `![alt](x.png){width="500"}` - CommonMark has no syntax
+        for this, so it otherwise tokenizes as a literal "{width=..}" text
+        run right after the image) into that image's own HTML attributes
+        instead of leaving it as visible text."""
+        result = []
+        for tok in tokens:
+            if tok.type == "text" and result and result[-1].type == "image":
+                m = ATTR_LINE_RE.match(tok.content.strip())
+                if m:
+                    result[-1].attrs.update(parse_attrs(m.group(1)))
+                    continue
+            if tok.children:
+                tok.children = self.fold_image_attrs(tok.children)
+            result.append(tok)
+        return result
+
+    def render_inline(self, inline_token: Token) -> str:
+        children = self.fold_image_attrs(inline_token.children)
+        return self.rewrite_urls(self.md.renderer.render(children, self.md.options, {}))
+
+    def convert_nodes(self, nodes: list) -> list:
+        blocks = []
+        for n in nodes:
+            result = self.convert_node(n)
+            if result is None:
+                continue
+            if isinstance(result, list):
+                blocks.extend(result)
+            else:
+                blocks.append(result)
+        blocks = self.merge_attr_lines(blocks)
+        blocks = self.group_containers(blocks)
+        return blocks
+
+    def convert_node(self, node: Node):
+        t = node.token
+        ttype = t.type
+
+        if ttype == "paragraph_open":
+            inline = node.children[0].token
+            # "_raw" carries the unescaped markdown source so merge_attr_lines
+            # can detect/parse a trailing "{...}" attribute line; it is
+            # stripped out of the final block before output.
+            return {"type": "paragraph", "html": self.render_inline(inline), "_raw": inline.content}
+
+        if ttype == "heading_open":
+            inline = node.children[0].token
+            level = int(t.tag[1:])
+            text = inline.content
+            return {
+                "type": "heading",
+                "level": level,
+                "id": slugify(text),
+                "html": self.render_inline(inline),
+            }
+
+        if ttype == "fence":
+            return {
+                "type": "code",
+                "lang": (t.info or "").strip() or None,
+                "code": t.content,
+                "attrs": {},
+            }
+
+        if ttype == "blockquote_open":
+            return {
+                "type": "blockquote",
+                "attrs": {},
+                "blocks": self.convert_nodes(node.children),
+            }
+
+        if ttype in ("bullet_list_open", "ordered_list_open"):
+            items = []
+            for item_node in node.children:
+                if item_node.token.type == "list_item_open":
+                    items.append({"blocks": self.convert_nodes(item_node.children)})
+            return {"type": "list", "ordered": ttype == "ordered_list_open", "items": items}
+
+        if ttype == "table_open":
+            headers = []
+            rows = []
+            for section in node.children:
+                if section.token.type == "thead_open":
+                    for tr in section.children:
+                        row = [self.render_inline(td.children[0].token) for td in tr.children]
+                        headers = row
+                elif section.token.type == "tbody_open":
+                    for tr in section.children:
+                        row = [self.render_inline(td.children[0].token) for td in tr.children]
+                        rows.append(row)
+            return {"type": "table", "headers": headers, "rows": rows}
+
+        if ttype == "hr":
+            return {"type": "hr"}
+
+        if ttype == "html_block":
+            # CommonMark merges consecutive non-blank-line-separated HTML
+            # lines into a single html_block token, so a lone <tabs ...> and
+            # the <tab ...> that immediately follows it commonly land in the
+            # same token. Split back into lines so each tag can be matched
+            # (and grouped into a container) independently.
+            result = []
+            raw_run = []
+
+            def flush_raw():
+                if raw_run:
+                    result.append({"type": "html", "html": self.rewrite_urls("\n".join(raw_run))})
+                    raw_run.clear()
+
+            for line in t.content.splitlines():
+                m = TAG_RE.match(line.strip())
+                if m:
+                    flush_raw()
+                    closing, tag, attrstr = m.groups()
+                    result.append({
+                        "type": "tag_marker",
+                        "closing": bool(closing),
+                        "tag": tag.lower(),
+                        "attrs": parse_attrs(attrstr),
+                    })
+                elif line.strip():
+                    raw_run.append(line)
+            flush_raw()
+            return result
+
+        if ttype == "inline":
+            # top-level bare inline content (e.g. an attribute line with no
+            # surrounding paragraph); treat like a paragraph.
+            return {"type": "paragraph", "html": self.render_inline(t), "_raw": t.content}
+
+        # Fallback: anything not explicitly handled (images are inline-only,
+        # so plain "image" blocks don't occur at block level; captured via
+        # paragraph HTML instead).
+        return {"type": "html", "html": self.rewrite_urls(str(t.content or ""))}
+
+    @staticmethod
+    def merge_attr_lines(blocks: list) -> list:
+        """Fold a standalone `{key="value"}` paragraph into the preceding block's attrs."""
+        merged = []
+        for b in blocks:
+            if b["type"] == "paragraph":
+                raw = b.pop("_raw", "").strip()
+                m = ATTR_LINE_RE.match(raw)
+                if m and merged:
+                    merged[-1].setdefault("attrs", {}).update(parse_attrs(m.group(1)))
+                    continue
+            merged.append(b)
+        return merged
+
+    @staticmethod
+    def group_containers(blocks: list) -> list:
+        """Turn <tabs>/<tab>/<note>/<tip>/<warning> tag_marker pairs into nested blocks."""
+        root: dict = {"blocks": []}
+        stack = [root]
+        for b in blocks:
+            if b["type"] == "tag_marker":
+                if not b["closing"]:
+                    node = {"type": b["tag"], "attrs": b["attrs"], "blocks": []}
+                    stack[-1]["blocks"].append(node)
+                    stack.append(node)
+                elif len(stack) > 1 and stack[-1]["type"] == b["tag"]:
+                    stack.pop()
+                continue
+            stack[-1]["blocks"].append(b)
+
+        return Converter._finalize_list(root["blocks"])
+
+    @staticmethod
+    def _finalize_list(blocks: list) -> list:
+        """Maps _finalize_container over a list, splicing in any block it
+        unwraps back into a plain list instead of a "tabs" block (see below)
+        in place, rather than nesting a list-within-a-list."""
+        result = []
+        for b in blocks:
+            out = Converter._finalize_container(b)
+            if isinstance(out, list):
+                result.extend(out)
+            else:
+                result.append(out)
+        return result
+
+    @staticmethod
+    def _finalize_container(b: dict):
+        if b.get("type") == "tabs" and "blocks" in b:
+            children = Converter._finalize_list(b["blocks"])
+            tab_children = [c for c in children if c.get("type") == "tab"]
+            if tab_children:
+                # Well-formed <tabs><tab>...</tab>...</tabs>.
+                return {
+                    "type": "tabs",
+                    "attrs": b["attrs"],
+                    "tabs": [
+                        {"title": c["attrs"].get("title"), "attrs": c["attrs"], "blocks": c["blocks"]}
+                        for c in tab_children
+                    ],
+                }
+            if len(children) >= 2 and all(c.get("type") == "code" for c in children):
+                # Bare <tabs> wrapping only fenced code blocks with no <tab>
+                # tags at all (seen in some compatibility guide pages, e.g.
+                # a Kotlin and a Groovy fence back to back) - Writerside
+                # authors apparently rely on adjacency here instead of
+                # writing <tab> explicitly, so treat each code block's own
+                # language as its tab instead of rendering a tabs shell with
+                # no tabs in it (which silently dropped every one of these
+                # code blocks - see the "type": "tabs" but no "tabs" key
+                # schema mismatch this used to produce).
+                return {
+                    "type": "tabs",
+                    "attrs": b["attrs"],
+                    "tabs": [
+                        {
+                            "title": (c["lang"] or "").capitalize() or f"Tab {i + 1}",
+                            "attrs": {"group-key": (c["lang"] or "").lower() or str(i + 1)},
+                            "blocks": [c],
+                        }
+                        for i, c in enumerate(children)
+                    ],
+                }
+            # Bare <tabs> wrapper with no <tab> children and no recognizable
+            # tab structure to synthesize - there's nothing tab-like left to
+            # preserve, so drop the wrapper and splice its content in place
+            # instead of emitting a "tabs" block with no "tabs" key (which
+            # templates/page.peb can't render - it silently produces an
+            # empty <div class="tabs"> and drops the content entirely).
+            return children
+        if "blocks" in b:
+            b["blocks"] = Converter._finalize_list(b["blocks"])
+        return b
+
+    def convert_file(self, path: Path, page_id: str, source_rel: str) -> dict:
+        self.current_source = source_rel
+        raw = path.read_text(encoding="utf-8")
+        # Substitute %variables% in the raw source, before markdown-it ever
+        # sees it. Doing this post-render instead would (a) miss the title,
+        # which is extracted straight from the raw source, and (b) run into
+        # markdown-it percent-encoding "%" inside link URLs, which turns
+        # "%kotlinEapVersion%" into "%25kotlinEapVersion%25" before we'd get
+        # a chance to match it.
+        raw = substitute_vars(raw, self.variables)
+        title, body = extract_title(raw)
+        tokens = self.md.parse(body)
+        tree = build_tree(tokens)
+        blocks = self.convert_nodes(tree)
+        return {
+            "id": page_id,
+            "sourceFile": source_rel,
+            "title": title,
+            "blocks": blocks,
+        }
+
+
+def make_markdown_it() -> MarkdownIt:
+    md = MarkdownIt("commonmark")
+    md.enable("table")
+    return md
+
+
+CONFIG_KEYS = ("broken-ext-link-color", "menu-no-link-color")
+
+
+def load_config(config_path: Path) -> dict:
+    """Loads the {"broken-ext-link-color": ..., "menu-no-link-color": ...}
+    theming config. Missing keys just disable that particular styling (a
+    warning is printed) rather than being a hard error, since neither is
+    required for the JSON conversion itself to be correct."""
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+    for key in CONFIG_KEYS:
+        if key not in config:
+            print(f"warning: config {config_path} is missing {key!r}; that styling will be skipped", file=sys.stderr)
+    return config
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("docs_root", type=Path, help="Path to kotlin-web-site/docs")
+    parser.add_argument("output_dir", type=Path, help="Directory to write JSON files into")
+    parser.add_argument("config", type=Path,
+                         help='Path to a JSON config with "broken-ext-link-color" and "menu-no-link-color"')
+    parser.add_argument("--topics-subdir", default="topics", help="Subdirectory of docs_root holding .md files")
+    parser.add_argument("--images-subdir", default="images", help="Subdirectory of docs_root holding image files")
+    args = parser.parse_args()
+
+    docs_root: Path = args.docs_root
+    topics_dir = docs_root / args.topics_subdir
+    images_dir = docs_root / args.images_subdir
+    if not topics_dir.is_dir():
+        print(f"error: {topics_dir} is not a directory", file=sys.stderr)
+        sys.exit(1)
+    if not args.config.is_file():
+        print(f"error: {args.config} does not exist", file=sys.stderr)
+        sys.exit(1)
+
+    config = load_config(args.config)
+    variables = load_variables(docs_root)
+    topic_index = build_topic_index(topics_dir)
+    image_index, _image_collisions = build_image_index(images_dir)
+    md = make_markdown_it()
+    converter = Converter(md, variables, topic_index, image_index,
+                           broken_ext_link_color=config.get("broken-ext-link-color"))
+
+    md_files = sorted(topics_dir.rglob("*.md"))
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    # menu-no-link-color applies to the sidebar, which build_nav.py builds
+    # separately from nav.json/kr.tree - it reads this back from the output
+    # directory it's already given, rather than needing its own copy of the
+    # config on its own command line.
+    (args.output_dir / "theme.json").write_text(
+        json.dumps({key: config.get(key) for key in CONFIG_KEYS}, indent=2), encoding="utf-8"
+    )
+
+    if images_dir.is_dir():
+        shutil.copytree(images_dir, args.output_dir / "images", dirs_exist_ok=True)
+    else:
+        print(f"warning: {images_dir} not found; image references will 404", file=sys.stderr)
+
+    count = 0
+    for md_path in md_files:
+        rel = md_path.relative_to(topics_dir)
+        page_id = str(rel.with_suffix(""))
+        source_rel = str(Path(args.topics_subdir) / rel)
+        try:
+            page = converter.convert_file(md_path, page_id, source_rel)
+        except Exception as exc:  # noqa: BLE001 - surface which file broke
+            print(f"error converting {md_path}: {exc}", file=sys.stderr)
+            continue
+        out_path = args.output_dir / args.topics_subdir / rel.with_suffix(".json")
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(json.dumps(page, separators=(",", ":"), ensure_ascii=False), encoding="utf-8")
+        count += 1
+
+    print(f"Converted {count}/{len(md_files)} files into {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/md_to_json.py
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/md_to_json.py
@@ -38,11 +38,16 @@ Block shapes:
   {"type": "blockquote", "attrs": {"style": "note"}, "blocks": [...]}
   {"type": "list", "ordered": false, "items": [{"blocks": [...]}]}
   {"type": "table", "headers": ["a", "b"], "rows": [["1", "2"]]}
-  {"type": "image", "src": "...", "alt": "..."}
   {"type": "hr"}
   {"type": "tabs", "attrs": {"group": "build-system"},
    "tabs": [{"title": "Gradle", "attrs": {"group-key": "gradle"}, "blocks": [...]}]}
   {"type": "html", "html": "<raw passthrough for anything unrecognized>"}
+
+There is no standalone "image" block type - CommonMark only ever produces
+"image" as an inline token nested inside a paragraph/heading/etc., so a
+`![alt](foo.png)` in the source always ends up as an <img> inside that
+block's own "html" string (via render_inline), never as a top-level block
+of its own.
 
 Cross-page links (`[text](other-page.md#anchor)`) and images (`![alt](foo.png)`)
 use Writerside's bare-filename convention - the referenced file is looked up
@@ -114,8 +119,15 @@ COLOR_RE = re.compile(r"^#[0-9a-fA-F]{3,8}$|^[a-zA-Z]+$")
 # twice) so the two can't silently diverge. The (?![\w-]) after the
 # alternation is load-bearing: without it, "tab" matches as a prefix of
 # "table", consuming "<table>" as tag "tab" with attrs "le".
+#
+# Group 3 (attrs) is non-greedy and group 4 (self-closing "/") is anchored
+# right before the final ">" - with a single greedy "([^>]*)/?>$" instead,
+# the attrs group swallows a self-closing tag's trailing "/" before the
+# optional "/?" ever gets a chance to match it, so "<tab .../>" came out
+# indistinguishable from "<tab ...>": an opener with no matching closer,
+# silently nesting the rest of the page inside it.
 CONTAINER_TAGS = {"tabs", "tab", "note", "tip", "warning"}
-TAG_RE = re.compile(r"^<(/?)(" + "|".join(CONTAINER_TAGS) + r")(?![\w-])([^>]*)/?>$", re.I)
+TAG_RE = re.compile(r"^<(/?)(" + "|".join(CONTAINER_TAGS) + r")(?![\w-])([^>]*?)\s*(/?)>$", re.I)
 
 
 def build_topic_index(topics_dir: Path) -> dict:
@@ -476,7 +488,14 @@ class Converter:
                 block["attrs"] = heading_attrs
             return block
 
-        if ttype == "fence":
+        if ttype in ("fence", "code_block"):
+            # code_block is markdown-it's token for indented (4-space) code,
+            # as opposed to fence (```-delimited) - it carries no language
+            # info, but otherwise wants the same "code" block shape. Without
+            # this case it fell through to the generic fallback below and
+            # came out as an unescaped "html" block instead - raw <, & etc.
+            # in the code would be interpreted as markup rather than shown
+            # as text, and it lost its code typing entirely.
             return {
                 "type": "code",
                 "lang": (t.info or "").strip() or None,
@@ -533,13 +552,23 @@ class Converter:
                 m = TAG_RE.match(line.strip())
                 if m:
                     flush_raw()
-                    closing, tag, attrstr = m.groups()
-                    result.append({
-                        "type": "tag_marker",
-                        "closing": bool(closing),
-                        "tag": tag.lower(),
-                        "attrs": parse_attrs(attrstr),
-                    })
+                    closing, tag, attrstr, self_closing = m.groups()
+                    attrs = parse_attrs(attrstr)
+                    tag = tag.lower()
+                    if self_closing:
+                        # "<tab .../>" has no children and no separate
+                        # closer - emit the open/close pair immediately
+                        # rather than treating it as an opener that leaves
+                        # the container open for the rest of the page.
+                        result.append({"type": "tag_marker", "closing": False, "tag": tag, "attrs": attrs})
+                        result.append({"type": "tag_marker", "closing": True, "tag": tag, "attrs": {}})
+                    else:
+                        result.append({
+                            "type": "tag_marker",
+                            "closing": bool(closing),
+                            "tag": tag,
+                            "attrs": attrs,
+                        })
                 elif line.strip():
                     raw_run.append(line)
             flush_raw()

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/review_build_json.sh
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/review_build_json.sh
@@ -1,21 +1,25 @@
 #!/usr/bin/env bash
-# Throwaway helper for reviewers of ADFA-5039 - installs requirements, clones
-# kotlin-web-site, and runs md_to_json.py against it so you can look at real
-# JSON output without any other setup. Not part of the actual pipeline
-# (that's ADFA-4739, a separate ticket/PR).
+# Throwaway helper for reviewers of ADFA-5039 - clones kotlin-web-site and
+# runs md_to_json.py against it via `uv run` so you can look at real JSON
+# output without any other setup. Not part of the actual pipeline (that's
+# ADFA-4739, a separate ticket/PR).
 set -euo pipefail
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-WORKDIR="$(mktemp -d)"
+if ! command -v uv >/dev/null 2>&1; then
+  echo "error: uv is required - see https://docs.astral.sh/uv/getting-started/installation/" >&2
+  exit 1
+fi
 
-echo "== Installing requirements =="
-python3 -m pip install markdown-it-py
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../../.." && pwd)"
+WORKDIR="$(mktemp -d)"
 
 echo "== Cloning kotlin-web-site into $WORKDIR/kotlin-web-site =="
 git clone --depth 1 https://github.com/JetBrains/kotlin-web-site.git "$WORKDIR/kotlin-web-site"
 
 echo "== Running md_to_json.py =="
-python3 "$SCRIPT_DIR/md_to_json.py" \
+uv run --with-requirements "$REPO_ROOT/requirements.txt" \
+  "$SCRIPT_DIR/md_to_json.py" \
   "$WORKDIR/kotlin-web-site/docs" \
   "$WORKDIR/json-output" \
   "$SCRIPT_DIR/config.json"

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/review_build_json.sh
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/review_build_json.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Throwaway helper for reviewers of ADFA-5039 - installs requirements, clones
+# kotlin-web-site, and runs md_to_json.py against it so you can look at real
+# JSON output without any other setup. Not part of the actual pipeline
+# (that's ADFA-4739, a separate ticket/PR).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WORKDIR="$(mktemp -d)"
+
+echo "== Installing requirements =="
+python3 -m pip install markdown-it-py
+
+echo "== Cloning kotlin-web-site into $WORKDIR/kotlin-web-site =="
+git clone --depth 1 https://github.com/JetBrains/kotlin-web-site.git "$WORKDIR/kotlin-web-site"
+
+echo "== Running md_to_json.py =="
+python3 "$SCRIPT_DIR/md_to_json.py" \
+  "$WORKDIR/kotlin-web-site/docs" \
+  "$WORKDIR/json-output" \
+  "$SCRIPT_DIR/config.json"
+
+echo
+echo "Done. JSON output at $WORKDIR/json-output"

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/tests/conftest.py
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/tests/conftest.py
@@ -1,0 +1,4 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/tests/test_md_to_json.py
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/tests/test_md_to_json.py
@@ -110,7 +110,11 @@ def test_fold_image_attrs_preserves_trailing_prose():
     out = make_converter().fold_image_attrs([img, text])
     assert img.attrs == {"width": "25", "type": "joined"}
     assert len(out) == 2
-    assert out[1].content == "Slack:"
+    # Asserting the exact string (not .strip()'d) matters here: the
+    # remainder used to be re-stripped after slicing, silently eating the
+    # leading space that separates the image from this text - "Slack:"
+    # would pass that bug just as well as " Slack:" does.
+    assert out[1].content == " Slack:"
 
 
 def test_fold_image_attrs_single_group_still_leaves_no_leftover_token():
@@ -207,6 +211,22 @@ def test_well_formed_open_close_does_not_warn():
     assert conv.warnings == []
 
 
+def test_top_level_unmatched_closer_does_not_crash():
+    """A closing tag_marker with no matching opener anywhere on the stack -
+    stack is back down to the bare {"blocks": []} root, which has no "type"
+    key at all - used to raise KeyError('type') instead of hitting the
+    already-correct "no matching frame" warning path."""
+    blocks = [
+        {"type": "tag_marker", "closing": True, "tag": "note", "attrs": {}},
+        {"type": "paragraph", "html": "After."},
+    ]
+    conv = make_converter()
+    conv.current_source = "test.md"
+    result = conv.group_containers(blocks)
+    assert [b["html"] for b in result if b.get("type") == "paragraph"] == ["After."]
+    assert any(w["kind"] == "tag" for w in conv.warnings)
+
+
 # --- style_broken_and_external_links: no duplicate style= ---------------
 
 def test_broken_link_style_merges_into_existing_style_attr():
@@ -218,6 +238,19 @@ def test_broken_link_style_merges_into_existing_style_attr():
     assert html.count('style="') == 1
     assert "color: #cc0000" in html
     assert "font-weight:bold" in html
+
+
+def test_broken_link_style_merge_inserts_semicolon_separator():
+    """The merge used to concatenate the existing style value and the
+    injected rule with just a space when the existing value had no trailing
+    ";" - "font-weight: bold color: red;" is ONE malformed CSS declaration,
+    which browsers discard entirely, losing both rules."""
+    conv = make_converter(broken_ext_link_color="#cc0000")
+    html = conv.style_broken_and_external_links(
+        '<a href="https://x.com" style="font-weight: bold">x</a>')
+    assert html.count('style="') == 1
+    assert "font-weight: bold;" in html
+    assert "color: #cc0000;" in html
 
 
 def test_non_broken_link_untouched():
@@ -248,6 +281,21 @@ def test_load_config_rejects_markup_injection_payload(tmp_path):
     config_path = tmp_path / "config.json"
     config_path.write_text(json.dumps({
         "broken-ext-link-color": 'red"><script>alert(1)</script>',
+        "menu-no-link-color": "#999999",
+    }))
+    with pytest.raises(SystemExit) as exc_info:
+        m.load_config(config_path)
+    assert exc_info.value.code == 1
+
+
+def test_load_config_rejects_non_string_color_value(tmp_path):
+    """A JSON number (an unquoted hex-like value is a plausible hand-edit
+    slip, e.g. writing cc0000 instead of "#cc0000") used to raise a bare
+    TypeError from COLOR_RE.match(int) instead of the intended clean
+    "invalid ... value" error the line below is meant to produce."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({
+        "broken-ext-link-color": 123,
         "menu-no-link-color": "#999999",
     }))
     with pytest.raises(SystemExit) as exc_info:
@@ -398,3 +446,13 @@ def test_main_prunes_stale_topic_json(tmp_path):
     assert _run_main(docs_root, out_dir, config).returncode == 0
     assert not (out_dir / "topics" / "good.json").exists()
     assert (out_dir / "topics" / "new.json").exists()
+
+
+def test_main_refuses_when_output_dir_is_docs_root(tmp_path):
+    """output_dir == docs_root makes topics_out_dir the very same directory
+    as the source topics/ - the pruning rmtree used to delete it outright,
+    with every already-globbed source file then failing to convert."""
+    docs_root, config = _write_minimal_docs_root(tmp_path)
+    result = _run_main(docs_root, docs_root, config)
+    assert result.returncode == 1
+    assert (docs_root / "topics" / "good.md").exists()

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/tests/test_md_to_json.py
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/tests/test_md_to_json.py
@@ -1,0 +1,400 @@
+"""Regression tests for md_to_json.py, one per bug found in PR #23 review.
+
+Each test's docstring names the finding it guards; several reuse the
+reviewers' own repro snippets verbatim so a future regression reproduces the
+exact case that was originally reported.
+"""
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+import md_to_json as m
+
+
+class FakeToken:
+    """Minimal stand-in for markdown_it.token.Token - just the attributes
+    fold_image_attrs/extract_trailing_attrs actually touch."""
+
+    def __init__(self, type_, content="", children=None):
+        self.type = type_
+        self.content = content
+        self.children = children
+        self.attrs = {}
+
+
+def make_converter(**kwargs):
+    return m.Converter(m.make_markdown_it(), {}, **kwargs)
+
+
+# --- TAG_RE: <table> must not match as tag "tab" -----------------------
+
+def test_tag_re_does_not_match_table():
+    """TAG_RE previously had no word boundary after the tag-name
+    alternation, so <table>/</table> matched as tag "tab" with attrs "le",
+    silently eating every raw HTML table in the corpus."""
+    assert m.TAG_RE.match("<table>") is None
+    assert m.TAG_RE.match("</table>") is None
+    assert m.TAG_RE.match("<tabindex>") is None
+
+
+def test_tag_re_still_matches_real_container_tags():
+    assert m.TAG_RE.match('<tabs group="build">') is not None
+    assert m.TAG_RE.match('<tab title="Gradle">') is not None
+    assert m.TAG_RE.match("</warning>") is not None
+
+
+# --- ATTR_PAIR_RE / parse_attrs -----------------------------------------
+
+def test_parse_attrs_allows_whitespace_around_equals():
+    """{ style = "note" } used to parse to {} entirely (ATTR_PAIR_RE
+    required name=value with no surrounding whitespace)."""
+    assert m.parse_attrs('style = "note"') == {"style": "note"}
+
+
+def test_parse_attrs_mixed_quoted_and_bare_pairs():
+    """The whole-string '="' check forced every bare value in the same
+    attr_str to '' as soon as ANY pair in it was quoted."""
+    assert m.parse_attrs('title="Gradle" group-key=gradle') == {
+        "title": "Gradle", "group-key": "gradle",
+    }
+
+
+def test_parse_attrs_quoted_empty_value_stays_empty_string():
+    assert m.parse_attrs('title=""') == {"title": ""}
+
+
+# --- merge_attr_lines: don't delete content that parsed to nothing -----
+
+def test_merge_attr_lines_keeps_paragraph_with_no_parsed_attrs():
+    """A {...}-shaped paragraph that parses to zero attrs (e.g. a lambda
+    literal, not a real attribute line) was deleted outright."""
+    blocks = [
+        {"type": "paragraph", "html": "Plain para", "_raw": "Plain para"},
+        {"type": "paragraph", "html": "{ it.length }", "_raw": "{ it.length }"},
+    ]
+    merged = m.Converter.merge_attr_lines(blocks)
+    assert [b["html"] for b in merged] == ["Plain para", "{ it.length }"]
+
+
+def test_merge_attr_lines_still_folds_a_real_attr_line():
+    blocks = [
+        {"type": "blockquote", "attrs": {}, "blocks": []},
+        {"type": "paragraph", "html": '{ style = "note" }', "_raw": '{ style = "note" }'},
+    ]
+    merged = m.Converter.merge_attr_lines(blocks)
+    assert len(merged) == 1
+    assert merged[0]["attrs"] == {"style": "note"}
+
+
+# --- fold_image_attrs: multiple brace groups + trailing prose ----------
+
+def test_fold_image_attrs_folds_multiple_adjacent_groups():
+    """`{width=25}{type="joined"}` used to be captured as ONE greedy
+    ATTR_LINE_RE match spanning both braces, so parse_attrs saw the literal
+    string 'width=25}{type="joined"' and produced {'width': ''}."""
+    img = FakeToken("image")
+    text = FakeToken("text", '{width=25}{type="joined"}')
+    make_converter().fold_image_attrs([img, text])
+    assert img.attrs == {"width": "25", "type": "joined"}
+
+
+def test_fold_image_attrs_preserves_trailing_prose():
+    """getting-started.md:89 - ![Slack](slack.svg){width=25}{type="joined"}
+    Slack: [get an invite](...) - the attribute groups must fold, but
+    "Slack: " must survive as visible text, not be silently dropped."""
+    img = FakeToken("image")
+    text = FakeToken("text", '{width=25}{type="joined"} Slack: ')
+    out = make_converter().fold_image_attrs([img, text])
+    assert img.attrs == {"width": "25", "type": "joined"}
+    assert len(out) == 2
+    assert out[1].content == "Slack:"
+
+
+def test_fold_image_attrs_single_group_still_leaves_no_leftover_token():
+    """Backward-compat: the original, common case (one attribute group,
+    nothing else) must still fold cleanly with no empty leftover token."""
+    img = FakeToken("image")
+    text = FakeToken("text", '{width="500"}')
+    out = make_converter().fold_image_attrs([img, text])
+    assert img.attrs == {"width": "500"}
+    assert out == [img]
+
+
+def test_fold_image_attrs_leaves_unrelated_text_alone():
+    img = FakeToken("image")
+    text = FakeToken("text", "just a caption, no braces")
+    out = make_converter().fold_image_attrs([img, text])
+    assert img.attrs == {}
+    assert out == [img, text]
+
+
+# --- <tabs> block: don't discard non-<tab> siblings ---------------------
+
+def test_tabs_block_preserves_intro_and_trailing_prose():
+    """Intro/trailing prose written inside a <tabs>...</tabs> block used to
+    vanish entirely - only <tab> children were kept."""
+    blocks = [
+        {"type": "tag_marker", "closing": False, "tag": "tabs", "attrs": {"group": "build"}},
+        {"type": "paragraph", "html": "Intro paragraph that should not vanish."},
+        {"type": "tag_marker", "closing": False, "tag": "tab", "attrs": {"title": "Gradle"}},
+        {"type": "paragraph", "html": "gradle body"},
+        {"type": "tag_marker", "closing": True, "tag": "tab", "attrs": {}},
+        {"type": "tag_marker", "closing": False, "tag": "tab", "attrs": {"title": "Maven"}},
+        {"type": "paragraph", "html": "maven body"},
+        {"type": "tag_marker", "closing": True, "tag": "tab", "attrs": {}},
+        {"type": "paragraph", "html": "Trailing note."},
+        {"type": "tag_marker", "closing": True, "tag": "tabs", "attrs": {}},
+    ]
+    conv = make_converter()
+    conv.current_source = "test.md"
+    result = conv.group_containers(blocks)
+    paragraphs = [b["html"] for b in result if b.get("type") == "paragraph"]
+    tabs_blocks = [b for b in result if b.get("type") == "tabs"]
+    assert "Intro paragraph that should not vanish." in paragraphs
+    assert "Trailing note." in paragraphs
+    assert len(tabs_blocks) == 1
+    assert len(tabs_blocks[0]["tabs"]) == 2
+
+
+def test_well_formed_tabs_with_no_siblings_unchanged():
+    blocks = [
+        {"type": "tag_marker", "closing": False, "tag": "tabs", "attrs": {}},
+        {"type": "tag_marker", "closing": False, "tag": "tab", "attrs": {"title": "A"}},
+        {"type": "paragraph", "html": "a"},
+        {"type": "tag_marker", "closing": True, "tag": "tab", "attrs": {}},
+        {"type": "tag_marker", "closing": True, "tag": "tabs", "attrs": {}},
+    ]
+    conv = make_converter()
+    conv.current_source = "test.md"
+    result = conv.group_containers(blocks)
+    assert len(result) == 1
+    assert result[0]["type"] == "tabs"
+
+
+# --- group_containers: mismatched closing tag ---------------------------
+
+def test_unmatched_closing_tag_does_not_relocate_trailing_content():
+    """A missing </tab> before </tabs> used to leave the </tabs> marker
+    silently discarded, keeping the tab frame open - content written after
+    the whole container ended up nested inside it instead."""
+    blocks = [
+        {"type": "tag_marker", "closing": False, "tag": "tabs", "attrs": {}},
+        {"type": "tag_marker", "closing": False, "tag": "tab", "attrs": {"title": "A"}},
+        {"type": "paragraph", "html": "body A"},
+        {"type": "tag_marker", "closing": True, "tag": "tabs", "attrs": {}},  # missing </tab> first
+        {"type": "paragraph", "html": "After everything."},
+    ]
+    conv = make_converter()
+    conv.current_source = "test.md"
+    result = conv.group_containers(blocks)
+    top_level_paragraphs = [b["html"] for b in result if b.get("type") == "paragraph"]
+    assert "After everything." in top_level_paragraphs
+    assert any(w["kind"] == "tag" for w in conv.warnings)
+
+
+def test_well_formed_open_close_does_not_warn():
+    blocks = [
+        {"type": "tag_marker", "closing": False, "tag": "note", "attrs": {}},
+        {"type": "paragraph", "html": "hi"},
+        {"type": "tag_marker", "closing": True, "tag": "note", "attrs": {}},
+    ]
+    conv = make_converter()
+    conv.current_source = "ok.md"
+    conv.group_containers(blocks)
+    assert conv.warnings == []
+
+
+# --- style_broken_and_external_links: no duplicate style= ---------------
+
+def test_broken_link_style_merges_into_existing_style_attr():
+    """Appending style="color: ...;" unconditionally left an <a> that
+    already had a style= with two style attributes - HTML5 keeps only the
+    first, silently dropping the color being added."""
+    conv = make_converter(broken_ext_link_color="#cc0000")
+    html = conv.style_broken_and_external_links('<a href="https://x.com" style="font-weight:bold">x</a>')
+    assert html.count('style="') == 1
+    assert "color: #cc0000" in html
+    assert "font-weight:bold" in html
+
+
+def test_non_broken_link_untouched():
+    conv = make_converter(broken_ext_link_color="#cc0000", topic_index={})
+    html = conv.style_broken_and_external_links('<a href="#anchor">x</a>')
+    assert html == '<a href="#anchor">x</a>'
+
+
+# --- rewrite_urls: src= scoped to <img>, not any element ---------------
+
+def test_src_rewrite_only_touches_img_tags():
+    """A bare src="..." regex also rewrote <script src=...>/<iframe
+    src=...>, running the image resolver against non-image filenames and
+    producing false "image not found" warnings for them."""
+    conv = make_converter(image_index={"x.js": "sub/x.js"})
+    html = conv.rewrite_urls('<script src="x.js"></script><iframe src="x.js"></iframe><img src="x.js">')
+    assert 'src="x.js"></script>' in html
+    assert 'src="x.js"></iframe>' in html
+    assert '/images/sub/x.js' in html
+    assert not any(w["kind"] == "image" for w in conv.warnings)
+
+
+# --- load_config: reject an unsafe/invalid color ------------------------
+
+def test_load_config_rejects_markup_injection_payload(tmp_path):
+    """broken-ext-link-color is interpolated directly into a style="..."
+    HTML attribute; an unvalidated value is a markup-injection hole."""
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({
+        "broken-ext-link-color": 'red"><script>alert(1)</script>',
+        "menu-no-link-color": "#999999",
+    }))
+    with pytest.raises(SystemExit) as exc_info:
+        m.load_config(config_path)
+    assert exc_info.value.code == 1
+
+
+def test_load_config_accepts_hex_and_named_colors(tmp_path):
+    config_path = tmp_path / "config.json"
+    config_path.write_text(json.dumps({
+        "broken-ext-link-color": "#cc0000",
+        "menu-no-link-color": "gray",
+    }))
+    config = m.load_config(config_path)
+    assert config["broken-ext-link-color"] == "#cc0000"
+    assert config["menu-no-link-color"] == "gray"
+
+
+# --- heading ids: de-dup + explicit {id=...} override -------------------
+
+def test_duplicate_heading_text_gets_deduped_ids():
+    """Two headings with identical text used to share a slug, so an anchor
+    to the second one landed on the first."""
+    conv = make_converter()
+    first = conv.unique_heading_id("Overview")
+    second = conv.unique_heading_id("Overview")
+    assert first == "overview"
+    assert second == "overview-2"
+
+
+def test_heading_trailing_id_attr_overrides_slug_and_is_stripped_from_html():
+    """## Checks with `is`/`!is` operators {id="is-and-is-operators"} used
+    to render the literal "{id=&quot;is-and-is-operators&quot;}" as visible
+    heading text, with no id override and no attribute handling at all."""
+    md = m.make_markdown_it()
+    conv = m.Converter(md, {})
+    tokens = md.parse('## Checks with `is` {id="is-and-is-operators"}\n')
+    tree = m.build_tree(tokens)
+    block = conv.convert_node(tree[0])
+    assert block["id"] == "is-and-is-operators"
+    assert "{id=" not in block["html"]
+    assert block["attrs"] == {"id": "is-and-is-operators"}
+
+
+def test_heading_without_trailing_attrs_unaffected():
+    md = m.make_markdown_it()
+    conv = m.Converter(md, {})
+    tokens = md.parse("## Plain heading\n")
+    tree = m.build_tree(tokens)
+    block = conv.convert_node(tree[0])
+    assert block["id"] == "plain-heading"
+    assert "attrs" not in block
+
+
+# --- build_topic_index: collision warning mirrors build_image_index -----
+
+def test_build_topic_index_warns_on_duplicate_stem(tmp_path, capsys):
+    """Two topics sharing a filename stem used to resolve first-wins with
+    no diagnostic at all, unlike the equivalent image-filename collision."""
+    topics = tmp_path / "topics"
+    (topics / "native").mkdir(parents=True)
+    (topics / "js").mkdir(parents=True)
+    (topics / "native" / "basics.md").write_text("native")
+    (topics / "js" / "basics.md").write_text("js")
+
+    index = m.build_topic_index(topics)
+    assert index["basics"] in ("native/basics", "js/basics")
+    assert "warning: ambiguous topic filename 'basics'" in capsys.readouterr().err
+
+
+def test_build_topic_index_no_warning_without_collision(tmp_path, capsys):
+    topics = tmp_path / "topics"
+    topics.mkdir()
+    (topics / "a.md").write_text("a")
+    m.build_topic_index(topics)
+    assert capsys.readouterr().err == ""
+
+
+# --- main(): exit code reflects partial failure -------------------------
+
+def _write_minimal_docs_root(tmp_path):
+    docs_root = tmp_path / "docs"
+    (docs_root / "topics").mkdir(parents=True)
+    (docs_root / "topics" / "good.md").write_text("# Good\n\nHello.\n")
+    config = tmp_path / "config.json"
+    config.write_text(json.dumps({"broken-ext-link-color": "#cc0000", "menu-no-link-color": "#999999"}))
+    return docs_root, config
+
+
+def _run_main(*args):
+    script = Path(__file__).resolve().parent.parent / "md_to_json.py"
+    return subprocess.run([sys.executable, str(script), *map(str, args)], capture_output=True, text=True)
+
+
+def test_main_exits_zero_on_full_success(tmp_path):
+    docs_root, config = _write_minimal_docs_root(tmp_path)
+    out_dir = tmp_path / "out"
+    result = _run_main(docs_root, out_dir, config)
+    assert result.returncode == 0
+    assert "Converted 1/1" in result.stdout
+
+
+def test_main_exits_nonzero_when_a_file_fails(tmp_path, monkeypatch):
+    """A run that converts nothing (or partially fails) used to print
+    "Converted 0/N files" and still exit 0 - a CI step calling this
+    couldn't distinguish a complete run from a total failure."""
+    docs_root, config = _write_minimal_docs_root(tmp_path)
+    # A .md file that isn't valid UTF-8 makes convert_file's read_text raise.
+    (docs_root / "topics" / "bad.md").write_bytes(b"\xff\xfe not utf-8")
+    out_dir = tmp_path / "out"
+    result = _run_main(docs_root, out_dir, config)
+    assert result.returncode == 1
+    assert "Converted 1/2" in result.stdout
+
+
+def test_main_allow_failures_exits_zero_despite_failure(tmp_path):
+    docs_root, config = _write_minimal_docs_root(tmp_path)
+    (docs_root / "topics" / "bad.md").write_bytes(b"\xff\xfe not utf-8")
+    out_dir = tmp_path / "out"
+    result = _run_main(docs_root, out_dir, config, "--allow-failures")
+    assert result.returncode == 0
+
+
+def test_main_uses_posix_separators_for_nested_page_ids(tmp_path):
+    """page_id/sourceFile used str(Path(...)) instead of .as_posix(), which
+    would disagree with build_topic_index's forward-slashed ids on Windows."""
+    docs_root, config = _write_minimal_docs_root(tmp_path)
+    (docs_root / "topics" / "tour").mkdir()
+    (docs_root / "topics" / "tour" / "hello.md").write_text("# Hello\n")
+    out_dir = tmp_path / "out"
+    result = _run_main(docs_root, out_dir, config)
+    assert result.returncode == 0
+    page = json.loads((out_dir / "topics" / "tour" / "hello.json").read_text())
+    assert page["id"] == "tour/hello"
+    assert page["sourceFile"] == "topics/tour/hello.md"
+
+
+def test_main_prunes_stale_topic_json(tmp_path):
+    """A topic removed upstream used to keep shipping its stale JSON
+    forever, since nothing ever cleared the output topics directory."""
+    docs_root, config = _write_minimal_docs_root(tmp_path)
+    out_dir = tmp_path / "out"
+    assert _run_main(docs_root, out_dir, config).returncode == 0
+    assert (out_dir / "topics" / "good.json").exists()
+
+    (docs_root / "topics" / "good.md").unlink()
+    (docs_root / "topics" / "new.md").write_text("# New\n")
+    assert _run_main(docs_root, out_dir, config).returncode == 0
+    assert not (out_dir / "topics" / "good.json").exists()
+    assert (out_dir / "topics" / "new.json").exists()

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/tests/test_md_to_json.py
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/tests/test_md_to_json.py
@@ -46,6 +46,66 @@ def test_tag_re_still_matches_real_container_tags():
     assert m.TAG_RE.match("</warning>") is not None
 
 
+# --- TAG_RE / html_block: self-closing tags must not stay open ----------
+
+def test_tag_re_captures_self_closing_marker_separately():
+    """The attrs group used to be greedy, so it swallowed a self-closing
+    tag's trailing "/" before the optional "/?" at the end ever got a
+    chance to match it - "<tab .../>" came out with an empty closing
+    group, i.e. indistinguishable from a plain opener."""
+    closing, tag, attrs, self_closing = m.TAG_RE.match('<tab title="A"/>').groups()
+    assert (closing, tag, self_closing) == ("", "tab", "/")
+    assert attrs.strip() == 'title="A"'
+
+    closing, tag, attrs, self_closing = m.TAG_RE.match('<tab title="A">').groups()
+    assert self_closing == ""
+
+
+def test_html_block_self_closing_tag_emits_open_and_close_markers():
+    """convert_node's html_block dispatch must turn a self-closing tag into
+    an immediate open/close pair rather than a bare opener - otherwise the
+    container never closes and silently nests the rest of the page."""
+    node = m.Node(FakeToken("html_block", content='<tab title="A"/>'))
+    conv = make_converter()
+    result = conv.convert_node(node)
+    assert [(b["type"], b["closing"], b["tag"]) for b in result] == [
+        ("tag_marker", False, "tab"),
+        ("tag_marker", True, "tab"),
+    ]
+
+
+def test_self_closing_tag_does_not_swallow_trailing_content():
+    """End-to-end repro: a self-closing <tab/> immediately followed by a
+    paragraph must not leave that paragraph nested inside the tab."""
+    node = m.Node(FakeToken("html_block", content='<tab title="A"/>'))
+    conv = make_converter()
+    conv.current_source = "test.md"
+    markers = conv.convert_node(node)
+    blocks = markers + [{"type": "paragraph", "html": "After."}]
+    result = conv.group_containers(blocks)
+    assert [b["html"] for b in result if b.get("type") == "paragraph"] == ["After."]
+    assert conv.warnings == []
+
+
+# --- convert_node: indented code_block must render as code, not html ----
+
+def test_indented_code_block_renders_as_code_not_html():
+    """convert_node only handled markdown-it's "fence" (```-delimited)
+    token; an indented (4-space) code block produces a different token
+    type, "code_block", which fell through to the generic fallback and
+    came out as an unescaped "html" block instead - raw "<"/"&" in the
+    code would be interpreted as markup rather than shown as text, and the
+    block lost its code typing entirely."""
+    md = m.make_markdown_it()
+    conv = m.Converter(md, {})
+    tokens = md.parse('    List<String> x = listOf("a", "b");\n')
+    tree = m.build_tree(tokens)
+    block = conv.convert_node(tree[0])
+    assert block["type"] == "code"
+    assert block["lang"] is None
+    assert "List<String>" in block["code"]
+
+
 # --- ATTR_PAIR_RE / parse_attrs -----------------------------------------
 
 def test_parse_attrs_allows_whitespace_around_equals():

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ brotli
 Pillow
 openpyxl>=3.1.0
 tqdm-loggable>=0.1.0
+markdown-it-py


### PR DESCRIPTION
## Summary
Adds `md_to_json.py`, which converts a `kotlin-web-site/docs` checkout
(JetBrains Writerside-flavored Markdown) into the JSON block schema this
project's templating engine renders.

## Scope
This is split out of the larger end-to-end Kotlin-docs pipeline in
[#21](https://github.com/appdevforall/OfflineDocumentationTools/pull/21),
which is being separated into two ticket-scoped PRs:
- **ADFA-5039 (this PR)**: producing the JSON data for the Kotlin website.
- **ADFA-4739 (follow-up PR)**: `build_nav.py`, `find_missing_assets.py`,
  `populate_db.py`, media insertion, and the GitHub Action that loads
  everything into `documentation.db`. That PR depends on this one merging
  first, since `populate_db.py`/`build_nav.py` import `md_to_json.py`.

## Changes
- `ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/md_to_json.py` - the converter.
- `config.json` - theming config it takes as input.
- `markdown-it-py` added to root `requirements.txt`.
- `README.md` scoped to this script's usage and output schema.
- `review_build_json.sh` - a throwaway reviewer helper (installs
  requirements, clones `kotlin-web-site`, runs the converter) so you can see
  real JSON output with no other setup. Not part of the actual pipeline.

## Test plan
- [x] Ran `review_build_json.sh` locally end-to-end against a real
  `kotlin-web-site` clone - converted 304/304 files, output matches the
  documented schema (`topics/**/*.json`, `theme.json`, `images/`).
- [x] Reviewer confirms `md_to_json.py`/`config.json` match their originals
  in PR #21 (no edits made during the split).