### PR TITLE
ADFA-4739: Kotlin docs DB pipeline + Build Kotlin Docs GitHub Action

### DIFF
--- a/.github/workflows/build-kotlin-docs.yaml
+++ b/.github/workflows/build-kotlin-docs.yaml
@@ -1,0 +1,378 @@
+name: Build Kotlin Docs
+
+# CI counterpart of ProcessDocs/ProcessKotlinDocs/run_e2e_pipeline_test.sh -
+# same five steps (find_missing_assets -> populate_db -> insert_optimized_media
+# -> build-stdlib-json-docs -> sync_kdoc_json_to_db), same ADFA-4737 blacklist,
+# but sourcing its inputs from fresh git checkouts instead of a developer's
+# local machine, and reading/writing the real database on Google Drive
+# (GOOGLE_DRIVE_FILE_ID) instead of a local SOURCE_DB copy.
+#
+# KNOWN LIMITATION: populate_db.py requires Writerside's own image export
+# ("webHelpImages.zip"), which JetBrains only produces via IntelliJ IDEA's
+# Writerside plugin build/export action - there is no headless/CLI way to
+# generate it (see ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/README.md,
+# "Inputs you need before starting"). So this workflow downloads it from
+# Google Drive rather than generating it itself; someone has to run that IDE
+# export, upload the zip to Drive, and supply its file ID (see
+# images_zip_file_id / GOOGLE_DRIVE_IMAGES_ZIP_FILE_ID below) before
+# triggering a run that touches the website docs. Use skip_website_docs to
+# bypass this entirely and only refresh the kotlin-stdlib/-reflect/-test
+# JSON content.
+#
+# Required secrets (already configured - see docdb-regression-test.yaml for
+# their other use in this repo):
+#   GCP_WIF_PROVIDER        - Workload Identity Federation provider name
+#   GCP_WIF_SERVICE_ACCOUNT - Service account email for WIF (needs read
+#                              access to the images-zip file below, and
+#                              write access - not just view - to the
+#                              database file, since this workflow
+#                              overwrites it)
+#   GOOGLE_DRIVE_FILE_ID     - File ID of the production documentation.db
+#                              (stored on Drive as a zip)
+#
+# Optional secret (falls back to the images_zip_file_id input if unset; see
+# also the hard-coded TEST_*_FILE_ID overrides below for one-off testing):
+#   GOOGLE_DRIVE_IMAGES_ZIP_FILE_ID - File ID of Writerside's webHelpImages.zip export
+#
+# Optional secret (Slack notifications are skipped with a warning if unset):
+#   SLACK_WEBHOOK_URL - Incoming Webhook URL for the "Notify Slack" steps
+#                        below ("Grabbing baton" on start, "...Dropping
+#                        baton" on finish - org shorthand for lock
+#                        acquire/release, since this workflow mutates a
+#                        single shared Drive file).
+
+permissions:
+  contents: read
+  id-token: write
+
+# This workflow overwrites a single shared Drive file - never let two runs
+# race to upload against each other.
+concurrency:
+  group: build-kotlin-docs
+  cancel-in-progress: false
+
+on:
+  workflow_dispatch:
+    inputs:
+      kotlin_web_site_ref:
+        description: >-
+          Branch/tag/commit of JetBrains/kotlin-web-site to check out for the
+          "docs" tree (topics/, images/, kr.tree, v.list). Leave empty to use
+          the repo's default branch.
+        required: false
+        default: ''
+      kotlin_ref:
+        description: >-
+          Branch/tag/commit of JetBrains/kotlin to check out for the
+          kotlin-stdlib-docs build. Leave empty to use the repo's default
+          branch. Pin this to a real release tag for a reproducible build.
+        required: false
+        default: ''
+      images_zip_file_id:
+        description: >-
+          Google Drive file ID for Writerside's webHelpImages.zip export
+          matching kotlin_web_site_ref (see KNOWN LIMITATION above). Falls
+          back to the GOOGLE_DRIVE_IMAGES_ZIP_FILE_ID secret if left empty.
+          Ignored if skip_website_docs is true.
+        required: false
+        default: ''
+      skip_website_docs:
+        description: 'Skip the kotlin-web-site steps and only refresh kotlin-stdlib/-reflect/-test JSON content.'
+        required: false
+        default: false
+        type: boolean
+      dry_run:
+        description: >-
+          If true, build and verify everything but do NOT upload the result
+          back to Google Drive - the production database is left untouched.
+          Set to false only once you trust a given ref/URL combination (see
+          this workflow's testing notes).
+        required: false
+        default: true
+        type: boolean
+
+jobs:
+  build-kotlin-docs:
+    runs-on: ubuntu-latest
+    timeout-minutes: 180
+    env:
+      KOTLIN_WEB_SITE_REF: ${{ inputs.kotlin_web_site_ref }}
+      KOTLIN_REF: ${{ inputs.kotlin_ref }}
+      DB_FILE_ID_SECRET: ${{ secrets.GOOGLE_DRIVE_FILE_ID }}
+      IMAGES_ZIP_FILE_ID_INPUT: ${{ inputs.images_zip_file_id }}
+      IMAGES_ZIP_FILE_ID_SECRET: ${{ secrets.GOOGLE_DRIVE_IMAGES_ZIP_FILE_ID }}
+      # --- Hard-coded overrides for one-off manual testing -----------------
+      # Fill in either of these with a literal Google Drive file ID to
+      # bypass the secret/input resolution above for a quick, repeatable
+      # test run (e.g. against scratch copies of the database/images zip on
+      # Drive). Leave both empty ('') for normal operation.
+      TEST_DB_FILE_ID: ''
+      TEST_IMAGES_ZIP_FILE_ID: ''
+    steps:
+      - name: Checkout OfflineDocumentationTools
+        uses: actions/checkout@v4
+
+      - name: Resolve Google Drive file IDs
+        run: |
+          DB_FILE_ID="${TEST_DB_FILE_ID:-$DB_FILE_ID_SECRET}"
+          IMG_FILE_ID="${TEST_IMAGES_ZIP_FILE_ID:-${IMAGES_ZIP_FILE_ID_INPUT:-$IMAGES_ZIP_FILE_ID_SECRET}}"
+          if [ -z "$DB_FILE_ID" ]; then
+            echo "Error: no database file ID resolved - set the GOOGLE_DRIVE_FILE_ID secret, or TEST_DB_FILE_ID above for a test run" >&2
+            exit 1
+          fi
+          echo "Resolved DB_FILE_ID: ${DB_FILE_ID:+(set)}"
+          echo "Resolved IMG_FILE_ID: ${IMG_FILE_ID:+(set)}"
+          echo "DB_FILE_ID=$DB_FILE_ID" >> "$GITHUB_ENV"
+          echo "IMG_FILE_ID=$IMG_FILE_ID" >> "$GITHUB_ENV"
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Set up JDK (for the kdoc-to-json / kotlin-stdlib-docs Gradle builds)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          # kdoc-to-json's own Gradle wrapper is pinned to Gradle 9.1.0, which
+          # needs JDK 17+. Bump this if the kotlin checkout's own wrapper
+          # (invoked by build-stdlib-json-docs.sh against kotlin-stdlib-docs)
+          # turns out to need something newer - verify on first real run.
+          java-version: '17'
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update -y
+          sudo apt-get install -y pngquant unzip zip sqlite3
+
+      - name: Install Python dependencies
+        run: |
+          pip install -r requirements.txt
+          # markdown-it-py/scour/cairosvg: ProcessKotlinWebsiteJSON's own
+          # requirements (see its README), not in the root requirements.txt.
+          # google-api-python-client & friends: Drive download/upload, same
+          # libraries check-tools/download_database.py already depends on.
+          pip install markdown-it-py scour cairosvg \
+            google-api-python-client google-auth-httplib2 google-auth-oauthlib
+
+      - name: Authenticate to Google Cloud using Workload Identity Federation
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SERVICE_ACCOUNT }}
+          access_token_scopes: |
+            https://www.googleapis.com/auth/drive.file
+
+      - name: Download current documentation.db from Google Drive
+        run: |
+          python3 check-tools/download_database.py "$DB_FILE_ID" documentation.zip
+          unzip -o documentation.zip
+          if [ ! -f documentation.db ]; then
+            found="$(find . -maxdepth 2 -name documentation.db | head -n1)"
+            [ -n "$found" ] && mv "$found" documentation.db
+          fi
+          test -f documentation.db
+          sqlite3 documentation.db "SELECT 1;" > /dev/null
+          rm -f documentation.zip
+          echo "DB_SIZE=$(stat -c%s documentation.db 2>/dev/null || stat -f%z documentation.db)" >> "$GITHUB_ENV"
+
+      - name: 'Notify Slack: build started'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL not set - skipping Slack notification" >&2
+          else
+            curl -sS -X POST -H 'Content-type: application/json' \
+              --data '{"text": "Grabbing baton"}' \
+              "$SLACK_WEBHOOK_URL" || echo "warning: Slack notification failed" >&2
+          fi
+
+      - name: Clone kotlin-web-site
+        if: ${{ !inputs.skip_website_docs }}
+        run: |
+          ARGS=(--depth 1)
+          [ -n "$KOTLIN_WEB_SITE_REF" ] && ARGS+=(--branch "$KOTLIN_WEB_SITE_REF")
+          git clone "${ARGS[@]}" https://github.com/JetBrains/kotlin-web-site.git kotlin-web-site
+
+      - name: Download Writerside image export from Google Drive
+        if: ${{ !inputs.skip_website_docs }}
+        run: |
+          if [ -z "$IMG_FILE_ID" ]; then
+            echo "Error: no images-zip file ID resolved - set images_zip_file_id, the GOOGLE_DRIVE_IMAGES_ZIP_FILE_ID secret, or TEST_IMAGES_ZIP_FILE_ID above (see KNOWN LIMITATION in this workflow's header comment). Required unless skip_website_docs is true." >&2
+            exit 1
+          fi
+          # download_database.py is a generic Drive-file-by-ID downloader
+          # despite its name - reused here rather than duplicating the
+          # WIF/Drive-API download logic for a second file type.
+          python3 check-tools/download_database.py "$IMG_FILE_ID" webHelpImages.zip
+
+      - name: 'Step 1/5: find_missing_assets.py (source QA report)'
+        if: ${{ !inputs.skip_website_docs }}
+        run: |
+          python3 ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/find_missing_assets.py \
+            kotlin-web-site/docs missing-assets-report.md
+
+      - name: Upload missing-assets report
+        if: ${{ !inputs.skip_website_docs }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: missing-assets-report
+          path: missing-assets-report.md
+
+      - name: 'Step 2/5: populate_db.py (convert docs, prune blacklist, insert into db)'
+        if: ${{ !inputs.skip_website_docs }}
+        run: |
+          # Same three blacklist entries as run_e2e_pipeline_test.sh
+          # (ADFA-4737) - re-derive these from kotlin-web-site/docs/kr.tree
+          # if its nav structure has changed since this was written.
+          python3 ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/populate_db.py \
+            kotlin-web-site/docs \
+            ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/config.json \
+            webHelpImages.zip \
+            documentation.db \
+            --blacklisted-element-titles \
+              'Development\/Web development' \
+              'Interoperability\/Swift/Objective-C and C interop' \
+              'Interoperability\/JavaScript interop'
+
+      - name: 'Step 3/5: insert_optimized_media.py (re-optimize + reinsert images)'
+        if: ${{ !inputs.skip_website_docs }}
+        run: |
+          # --webp requires an "image/webp" ContentTypes row, which this
+          # database doesn't ship with by default (idempotent).
+          sqlite3 documentation.db \
+            "INSERT OR IGNORE INTO ContentTypes (value, compression) VALUES ('image/webp', 'brotli');"
+          mkdir -p media
+          unzip -q webHelpImages.zip -d media
+          python3 ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/insert_optimized_media.py \
+            media documentation.db \
+            --jpeg-quality 85 --webp --webp-quality 90 --verbose
+
+      - name: Clone kotlin (for kotlin-stdlib-docs)
+        run: |
+          ARGS=(--depth 1)
+          [ -n "$KOTLIN_REF" ] && ARGS+=(--branch "$KOTLIN_REF")
+          git clone "${ARGS[@]}" https://github.com/JetBrains/kotlin.git kotlin-repo
+
+      - name: 'Step 4/5: build-stdlib-json-docs.sh (fresh plugin build -> kotlin-stdlib/-reflect/-test JSON)'
+        id: stdlib_docs
+        run: |
+          OUTPUT="$(Dokka-plugin-kdoc2json/scripts/kotlin/build-stdlib-json-docs.sh kotlin-repo stdlib-json-build)"
+          echo "Generated JSON docs at $OUTPUT"
+          echo "all_libs_dir=$OUTPUT" >> "$GITHUB_OUTPUT"
+
+      - name: 'Step 5/5: sync_kdoc_json_to_db.py (overwrite kotlin-stdlib/-reflect/-test content)'
+        run: |
+          python3 scripts/sync_kotlin_stdlib_docs/sync_kdoc_json_to_db.py \
+            "${{ steps.stdlib_docs.outputs.all_libs_dir }}" --db documentation.db
+
+      - name: Summary
+        run: |
+          python3 - documentation.db <<'PYEOF'
+          import sqlite3
+          import sys
+
+          conn = sqlite3.connect(sys.argv[1])
+
+          def count(where, params=()):
+              return conn.execute(f"SELECT count(*) FROM Content WHERE {where}", params).fetchone()[0]
+
+          print(f"Database: {sys.argv[1]}")
+          print(f"  k/html/*             rows: {count('path LIKE ?', ('k/html/%',))}")
+          print(f"  k/html/images/*      rows: {count('path LIKE ?', ('k/html/images/%',))}")
+          print(f"  k/html/images/*.webp rows: {count('path LIKE ?', ('k/html/images/%.webp%',))}")
+          print(f"  k/kotlin-stdlib/*    rows: {count('path LIKE ? OR path = ?', ('k/kotlin-stdlib/%', 'k/kotlin-stdlib'))}")
+          print(f"  k/kotlin-reflect/*   rows: {count('path LIKE ? OR path = ?', ('k/kotlin-reflect/%', 'k/kotlin-reflect'))}")
+          print(f"  k/kotlin-test/*      rows: {count('path LIKE ? OR path = ?', ('k/kotlin-test/%', 'k/kotlin-test'))}")
+          conn.close()
+          PYEOF
+
+      - name: Blacklist pruning verification
+        if: ${{ !inputs.skip_website_docs }}
+        run: |
+          python3 - ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON kotlin-web-site/docs documentation.db \
+            'Development\/Web development' \
+            'Interoperability\/Swift/Objective-C and C interop' \
+            'Interoperability\/JavaScript interop' <<'PYEOF'
+          import sqlite3
+          import sys
+          import xml.etree.ElementTree as ET
+          from pathlib import Path
+
+          process_dir, docs_root, db_path, *blacklist_raw = sys.argv[1:]
+          sys.path.insert(0, process_dir)
+          import populate_db  # noqa: E402
+
+          root = ET.parse(Path(docs_root) / "kr.tree").getroot()
+          blacklisted_paths = {populate_db.parse_blacklist_path(raw) for raw in blacklist_raw}
+          blacklisted_stems, unmatched_paths = populate_db.prune_blacklisted_elements(root, blacklisted_paths)
+
+          conn = sqlite3.connect(db_path)
+          leftover = []
+          for stem in sorted(blacklisted_stems):
+              path = f"k/html/{stem}.html"
+              if conn.execute("SELECT 1 FROM Content WHERE path = ?", (path,)).fetchone():
+                  leftover.append(path)
+          conn.close()
+
+          print(f"Blacklisted toc-element path(s) checked: {len(blacklisted_paths)}")
+          for path in sorted(blacklisted_paths):
+              status = "unmatched (no such element in kr.tree)" if path in unmatched_paths else "matched"
+              print(f"  {' > '.join(path)}: {status}")
+          print(f"Topic page(s) expected removed: {len(blacklisted_stems)}")
+
+          if unmatched_paths:
+              print(f"FAIL: {len(unmatched_paths)} blacklist path(s) never matched a <toc-element>.")
+              sys.exit(1)
+          if leftover:
+              print(f"FAIL: {len(leftover)} blacklisted page(s) still present in the database:")
+              for path in leftover:
+                  print(f"  {path}")
+              sys.exit(1)
+
+          print(f"PASS: all {len(blacklisted_stems)} blacklisted topic page(s) confirmed absent from {db_path}.")
+          PYEOF
+
+      - name: Upload built database as workflow artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: documentation-db-${{ github.run_number }}
+          path: documentation.db
+          retention-days: 14
+
+      - name: Zip updated database for upload
+        if: ${{ !inputs.dry_run }}
+        run: zip -j documentation.zip documentation.db
+
+      - name: Upload updated database to Google Drive
+        if: ${{ !inputs.dry_run }}
+        run: |
+          python3 - <<'PYEOF'
+          import os
+          from google.auth import default
+          from googleapiclient.discovery import build
+          from googleapiclient.http import MediaFileUpload
+
+          file_id = os.environ["DB_FILE_ID"]
+          credentials, _ = default()
+          service = build("drive", "v3", credentials=credentials)
+          media = MediaFileUpload("documentation.zip", mimetype="application/zip", resumable=True)
+          updated = service.files().update(
+              fileId=file_id, media_body=media, fields="id, modifiedTime, md5Checksum"
+          ).execute()
+          print(f"Uploaded new revision of {file_id}: {updated}")
+          PYEOF
+
+      - name: 'Notify Slack: build complete'
+        if: ${{ !inputs.dry_run }}
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        run: |
+          if [ -z "$SLACK_WEBHOOK_URL" ]; then
+            echo "SLACK_WEBHOOK_URL not set - skipping Slack notification" >&2
+          else
+            curl -sS -X POST -H 'Content-type: application/json' \
+              --data '{"text": "Updated Kotlin documentation. Dropping baton"}' \
+              "$SLACK_WEBHOOK_URL" || echo "warning: Slack notification failed" >&2
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ __pycache__/
 *$py.class
 *.db
 *.sqlite
+run_e2e_pipeline_test.local.sh
+grep_content_blobs.local.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,192 @@
+# CLAUDE.md
+
+Guidance for Claude (and anyone else) working in this repository.
+
+## What this repository is
+
+App Dev For All builds **Code on the Go**, an Android IDE aimed at users with no or limited
+internet access
+(code: [appdevforall/CodeOnTheGo](https://github.com/appdevforall/CodeOnTheGo)). To support that,
+Java/Kotlin/Android API documentation is bundled into the app as a single SQLite file — the
+**documentation database** — rather than fetched from the web.
+
+The documentation database serves two distinct features in the IDE:
+
+1. **Tooltips (Tier 1/2).** When a user selects a keyword/symbol in the code editor, a dialog
+   shows short (Tier 1) and detailed (Tier 2) tooltip text if the selection matches an entry in
+   the DB. This lookup happens elsewhere in the CodeOnTheGo Android code (not in this repo, and
+   not in `WebServer.kt` — see below).
+2. **Content pages (Tier 3).** From a tooltip, the user can click through to a full documentation
+   page. Those pages (and other static content — HTML, images, PDFs) are served over HTTP by
+   **`WebServer.kt`**
+   ([CodeOnTheGo/app/src/main/java/com/itsaky/androidide/localWebServer/WebServer.kt](https://github.com/appdevforall/CodeOnTheGo/blob/stage/app/src/main/java/com/itsaky/androidide/localWebServer/WebServer.kt)),
+   which runs inside the app and reads directly from the `Content` (and, as of recently,
+   `Templates`/`Bookshelf`/`BookCategories`) tables of the same database.
+
+**This repository (`OfflineDocumentationTools`) is the collection of offline tools that build and
+edit that database** — it contains no part of the production Android app itself.
+
+> **Alex's standing caveat, worth repeating at the top of every session:** nothing in this
+> repository is guaranteed to work against the *current* production database. The schema has moved
+> forward (in the app / by hand) faster than the tooling in this repo has been updated. See
+> "Schema: current vs. what this repo expects" below — that gap is the most important thing to
+> understand before making changes here.
+
+## Schema: current vs. what this repo expects
+
+The schema below is what `~/documentation.db` (Alex's current production copy) actually contains,
+as of 2026-08-05:
+
+```sql
+CREATE TABLE Languages (id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT NOT NULL UNIQUE);
+CREATE TABLE ContentTypes (id INTEGER PRIMARY KEY AUTOINCREMENT, value TEXT NOT NULL UNIQUE, compression TEXT NOT NULL);
+CREATE TABLE TooltipCategories (id INTEGER PRIMARY KEY, category TEXT NOT NULL);
+CREATE TABLE TooltipButtonNumbers (id INTEGER UNIQUE); -- manually assigned display order
+CREATE TABLE Content (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, path TEXT NOT NULL, languageID INTEGER NOT NULL,
+    content BLOB NOT NULL, contentTypeID INTEGER NOT NULL, templateId INTEGER NOT NULL DEFAULT 0,
+    FOREIGN KEY (languageID) REFERENCES Languages(id), FOREIGN KEY (contentTypeID) REFERENCES ContentTypes(id),
+    UNIQUE('path')
+);
+CREATE TABLE Tooltips (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, categoryId INTEGER NOT NULL, tag TEXT NOT NULL,
+    summary TEXT NOT NULL, detail TEXT NOT NULL, UNIQUE (categoryId, tag),
+    FOREIGN KEY(categoryId) REFERENCES TooltipCategories(id)
+);
+CREATE TABLE TooltipButtons (
+    tooltipId INTEGER, buttonNumberId INTEGER, description TEXT, uri TEXT,
+    FOREIGN KEY(tooltipId) REFERENCES Tooltips(id), FOREIGN KEY(buttonNumberId) REFERENCES TooltipButtonNumbers(id)
+);
+CREATE TABLE LastChange (documentationSet TEXT, changeTime TIMESTAMP DEFAULT CURRENT_TIMESTAMP, who TEXT);
+CREATE TABLE Templates (id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL, content BLOB NOT NULL, UNIQUE('name'));
+CREATE TABLE BookCategories (id INTEGER PRIMARY KEY AUTOINCREMENT, category STRING, description STRING DEFAULT '', UNIQUE('category'));
+CREATE TABLE Bookshelf (contentID INTEGER NOT NULL, title STRING DEFAULT '', description STRING DEFAULT '',
+    bookCategoryID INTEGER, FOREIGN KEY (bookCategoryID) REFERENCES BookCategories(id), UNIQUE(title, bookCategoryId));
+-- Triggers keep Bookshelf in sync when a .pdf row is added to/removed from Content.
+CREATE TABLE PUCC_Students (...), PUCC_Classes (...), PUCC_Sections (...), PUCC_Professors (...),
+             PUCC_StudentAssignments (...), PUCC_ProfessorAssignments (...)
+-- Unrelated to documentation tooling (confirmed by Alex) — ignore, leave as-is, do not
+-- document or maintain further in this repo.
+```
+
+**`Templates`, `BookCategories`, and `Bookshelf` are not documentation cruft — `WebServer.kt`
+actively depends on them.** Its `/pr/bs` endpoint builds a JSON "bookshelf" payload straight from
+`Content` + `Bookshelf` + `BookCategories`, looks up a template named `'bookshelf'` in `Templates`,
+and renders it with the Pebble template engine. More generally, any `Content` row with a non-zero
+`templateId` gets its stored (decompressed) content run through the matching row in `Templates` as
+a Pebble template before being served. This is a real, current feature of the shipped server, not
+a placeholder.
+
+**Nothing that currently builds or writes to the database in this repository knows about any of
+that — and that's expected.** `Templates`/`Bookshelf`/`BookCategories` are populated by a separate
+plugin system, not by anything in this repo: App Dev For All supports plugins that write into the
+documentation database, including the bookshelf feature specifically —
+[appdevforall/bookshelf-plugin](https://github.com/appdevforall/bookshelf-plugin). So the absence
+of any `Templates`/`Bookshelf`/`BookCategories` handling here is not a gap to fill; it's out of
+scope for this repo. (A repo-wide search for `templateId`, `Templates`, `Bookshelf`,
+`BookCategories`, or `PUCC` turns up zero matches outside `WebServer.kt` itself, which is
+consistent with that division of responsibility.) Concretely, relative to the schema above:
+
+| Piece | What it thinks the schema is | Consequence |
+| --- | --- | --- |
+| `scripts/DocumentationDatabase.py` (used by `scripts/ingest.py`, and hence by `.github/workflows/publish-doc-db.yaml`) | `Content` / `Languages` / `ContentTypes` only, plus an optional `ide_tooltip_table`. Its constructor explicitly **raises `ValueError`** if it opens a DB containing any table outside that whitelist. | **This will refuse to open the current production `documentation.db` at all** — it will list `Tooltips`, `TooltipCategories`, `TooltipButtons`, `TooltipButtonNumbers`, `LastChange`, `Templates`, `BookCategories`, `Bookshelf`, and every `PUCC_*` table as "unexpected." This is the single biggest blocker to reusing this script as-is. |
+| `docdb-studio/SCHEMA.md` / `AGENTS.md` (states the schema is "locked," no migrations) | `Content` (no `templateId`, no `UNIQUE(path)`), `Tooltips`, `TooltipButtons`, `TooltipCategories`, `TooltipButtonNumbers`, `LastChange` (with a *different* shape: `documentationSet`/`changeTime`/`who` — this part does match current), plus a legacy `ide_tooltip_table`. Missing `templateId`, `Templates`, `BookCategories`, `Bookshelf`, `PUCC_*`. | Closest of the three documented schemas to reality, but still out of date. `docdb_studio.py`'s own "never change the schema" policy is itself now stale, since the live schema has already changed underneath it. |
+| `check-tools/README.md`'s embedded schema (and by extension the mental model behind `check-tools/db_health_checker.py`) | `Content` (no `templateId`, no `UNIQUE(path)`), `Tooltips`, `TooltipButtons`, `TooltipCategories`, `TooltipButtonNumbers`, and a *third* variant of `LastChange` (`now`/`who`). No `Templates`/`Bookshelf`/`BookCategories`/`PUCC_*`. | The health checker's required-table check still passes (it only checks that its known tables exist, not that no others do). Since `Templates`/`Bookshelf`/`BookCategories` are out of scope for this repo (see above), this is not being treated as something to fix right now. |
+
+There also appear to be **two unrelated tooltip storage formats** in this repo's history, and it's
+worth being deliberate about which one is current:
+
+- The **normalized** format (`Tooltips` + `TooltipCategories` + `TooltipButtons` +
+  `TooltipButtonNumbers`) — this is what's in the live schema above, what `docdb-studio` edits,
+  what `check-tools/db_health_checker.py` validates, and what `scripts/TooltipManager.py`
+  dumps/rebuilds via CSV.
+- A **legacy flat** format, a single `ide_tooltip_table(tooltipCategory, tooltipTag,
+  tooltipSummary, tooltipDetail, tooltipButtons)` table (button data packed as a JSON string in
+  one column) — written by `scripts/tooltips.py` (`TooltipDatabase`, driven by
+  `scripts/import_tooltips.py` from `SourceDocs/Tooltips/tooltips.xlsx`) and by
+  `scripts/load_android_data.py` (fed by pickle files that `scripts/android_tooltips.py` /
+  `scripts/java_tooltips.py` scrape from Android/Java HTML doc trees). **`ide_tooltip_table` does
+  not exist in the current production schema at all.**
+
+**`ide_tooltip_table` is officially dead (confirmed by Alex).** That means the entire chain that
+targets it — `scripts/tooltips.py`, `scripts/import_tooltips.py`, `scripts/android_tooltips.py`,
+`scripts/java_tooltips.py`, `scripts/android_html_page.py`, and `scripts/load_android_data.py` — is
+**deprecated legacy code**. It's left in the repo for reference/history, but none of it should be
+extended or relied on, and none of it writes to a table the shipped app or `docdb-studio` actually
+uses. Any future Android/Java tooltip work should target the normalized `Tooltips` /
+`TooltipCategories` / `TooltipButtons` / `TooltipButtonNumbers` tables instead (the same ones
+`docdb-studio` and `scripts/TooltipManager.py` already use for Kotlin tooltips).
+
+## Repository tour
+
+- **`docdb-studio/`** — a Flet (Flutter-for-Python) desktop GUI for browsing/editing `Tooltips` /
+  `TooltipCategories` / `TooltipButtons` and importing `Content`. Has its own `CLAUDE.md`,
+  `AGENTS.md`, `SCHEMA.md`, and a real pytest suite. Actively maintained (most recent commits in
+  the repo touch this tool), but per the table above, its documented schema is behind the live one.
+  That's an accepted state, not an active problem: schema evolution happens outside
+  `docdb-studio` (and outside this repo, e.g. via plugins — see below), and `docdb-studio` is
+  expected to catch up after the fact rather than lead. Its `AGENTS.md`/`SCHEMA.md` "never migrate
+  the schema" language should be read as "don't migrate it from in here," not as a claim that the
+  schema never changes.
+- **`check-tools/`** — `db_health_checker.py` (schema/integrity/referential checks against the
+  *old* normalized schema) plus `download_database.py`, a working Google Drive downloader
+  authenticated via GCP Workload Identity Federation (no long-lived keys). Wired into
+  `.github/workflows/docdb-regression-test.yaml`, which runs it daily against the production DB on
+  Drive.
+- **`scripts/`** — the original CLI toolbox. Live/current: `DocumentationDatabase.py` (Content
+  ingestion — see whitelist issue above), `ingest.py` (thin CLI over it, used by
+  `publish-doc-db.yaml`), `TooltipManager.py` (CSV ⇄ normalized-Tooltips round-trip),
+  `create_empty_database.py`, `list_database_documents.py`. **Deprecated/dead** (target the
+  removed `ide_tooltip_table` — see above, kept for reference only): `tooltips.py`,
+  `import_tooltips.py`, `android_tooltips.py`, `java_tooltips.py`, `android_html_page.py`,
+  `load_android_data.py`.
+- **`scripts/myServer.py`** — a minimal Python `http.server` reference implementation that predates
+  `WebServer.kt`. It queries a differently-cased `Documentation.db`, doesn't implement Brotli
+  decompression (there's a literal `TODO: Replace this function with Brotli decompression`), and
+  knows nothing about compression-aware content types, templates, or fragmentation. **This is not
+  what ships in the app** — treat it as historical/reference only, not as documentation of current
+  server behavior. `WebServer.kt` is the real thing.
+- **`Dokka-plugin-kdoc2json/`** — on `main`, this is just a `README.md` describing the intended
+  design plus a flowchart image; there is no code here yet. The actual implementation (the Dokka
+  `JsonRenderer`/`ModelMapper`/`LinkPostProcessor` plugin, its test suite, and the
+  `kotlin-stdlib-docs` build scripts) exists only on the unmerged branch **`fix/ADFA-4514`**. That
+  branch's diff against `main` also shows it removing recent `docdb-studio` work and all of
+  `scripts/pdfjs/` — almost certainly because the branch was cut before those were added and hasn't
+  been rebased, not because it intends to delete them. **Flagged: rebase `fix/ADFA-4514` onto
+  current `main` before merging**, to avoid actually deleting that work.
+- **`ProcessDocs/`** — HTML-processing pipelines that predate the "build docs as JSON" goal:
+  `ProcessKotlinDocs/` (turns Kotlin's HTML doc export into a self-contained HTML set + table of
+  contents, used by `.github/workflows/automate-kotlin.yaml`), `ProcessAndroidDevSite/`, `AndroidDocs/`
+  (holds `android-tooltips.pkl`, the pickle consumed by the now-deprecated `load_android_data.py`),
+  `ProcessPDFs/`.
+- **`SourceDocs/`** — raw inputs: `KotlinDocs/html`, `JavaDocs/html` + `java_keywords.html`,
+  `Tooltips/tooltips.xlsx`, `KotlinDocs/kotlin-spec.pdf`.
+- **`DocumentationAnalysis/`, `DocAnalysis/`, `png_optimization/`, `androidxtooltips/`** — Jupyter
+  notebooks and one-off scripts for doc-set size analysis, image/PNG compression experiments, and a
+  one-time AndroidX tooltip import (ADFA-1419). Not part of the critical build path.
+- **`.github/workflows/`** — three workflows: `automate-kotlin.yaml` (tag-triggered, builds the
+  Kotlin HTML doc bundle as a GitHub release asset), `publish-doc-db.yaml` (tag-triggered, runs the
+  `scripts/ingest.py` pipeline and releases the resulting `.sqlite`), `docdb-regression-test.yaml`
+  (daily cron, downloads the production DB from Google Drive via WIF and runs
+  `check-tools/main.py` against it). None of these have any Slack integration yet.
+
+## Decisions log
+
+Settled with Alex on 2026-08-05, folded into the sections above; recorded here so the reasoning
+isn't lost:
+
+- `ide_tooltip_table` and everything that targets it are dead. Treat as deprecated, not as a gap.
+- `Templates`/`Bookshelf`/`BookCategories` are populated by App Dev For All's plugin system
+  (e.g. [bookshelf-plugin](https://github.com/appdevforall/bookshelf-plugin)), not by this repo.
+  Not a gap to fill here.
+- `PUCC_*` tables are unrelated to documentation tooling. Ignore; leave as-is.
+- `fix/ADFA-4514` needs a rebase onto `main` before merge — noted above.
+- `docdb-studio`'s schema is expected to lag the live schema and catch up after the fact; that's
+  fine, no urgent update needed.
+- `check-tools/db_health_checker.py` is not being extended with `Templates`/`Bookshelf` checks
+  right now — deliberately out of scope for the moment.
+
+The one piece of this document that still describes an *active* problem rather than a settled
+scope boundary is `scripts/DocumentationDatabase.py`'s hard failure on unrecognized tables (see the
+table above) — that will need to be addressed before `scripts/ingest.py` /
+`publish-doc-db.yaml` can run against a current-schema database.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,9 +83,12 @@ plugin system, not by anything in this repo: App Dev For All supports plugins th
 documentation database, including the bookshelf feature specifically —
 [appdevforall/bookshelf-plugin](https://github.com/appdevforall/bookshelf-plugin). So the absence
 of any `Templates`/`Bookshelf`/`BookCategories` handling here is not a gap to fill; it's out of
-scope for this repo. (A repo-wide search for `templateId`, `Templates`, `Bookshelf`,
-`BookCategories`, or `PUCC` turns up zero matches outside `WebServer.kt` itself, which is
-consistent with that division of responsibility.) Concretely, relative to the schema above:
+scope for this repo. (A repo-wide search for `Templates`, `Bookshelf`, `BookCategories`, or `PUCC`
+turns up zero matches outside `WebServer.kt` itself, which is consistent with that division of
+responsibility. `templateId` itself is a different story - `populate_db.py` and
+`insert_optimized_media.py` both read/write it directly, since it's a plain column on `Content`
+they populate; it's only the `Templates` table and the plugin system that reference it that stay
+out of scope.) Concretely, relative to the schema above:
 
 | Piece | What it thinks the schema is | Consequence |
 | --- | --- | --- |
@@ -146,14 +149,11 @@ uses. Any future Android/Java tooltip work should target the normalized `Tooltip
   knows nothing about compression-aware content types, templates, or fragmentation. **This is not
   what ships in the app** — treat it as historical/reference only, not as documentation of current
   server behavior. `WebServer.kt` is the real thing.
-- **`Dokka-plugin-kdoc2json/`** — on `main`, this is just a `README.md` describing the intended
-  design plus a flowchart image; there is no code here yet. The actual implementation (the Dokka
-  `JsonRenderer`/`ModelMapper`/`LinkPostProcessor` plugin, its test suite, and the
-  `kotlin-stdlib-docs` build scripts) exists only on the unmerged branch **`fix/ADFA-4514`**. That
-  branch's diff against `main` also shows it removing recent `docdb-studio` work and all of
-  `scripts/pdfjs/` — almost certainly because the branch was cut before those were added and hasn't
-  been rebased, not because it intends to delete them. **Flagged: rebase `fix/ADFA-4514` onto
-  current `main` before merging**, to avoid actually deleting that work.
+- **`Dokka-plugin-kdoc2json/`** — the Dokka `JsonRenderer`/`ModelMapper`/`LinkPostProcessor` plugin,
+  its test suite, and the `kotlin-stdlib-docs` build scripts, merged to `main` via `fix/ADFA-4514`
+  (`4c6b8aef`). Consumed by `scripts/kotlin/build-stdlib-json-docs.sh` and
+  `scripts/sync_kotlin_stdlib_docs/sync_kdoc_json_to_db.py` (ADFA-4739) to generate and load
+  kotlin-stdlib/-reflect/-test JSON docs.
 - **`ProcessDocs/`** — HTML-processing pipelines that predate the "build docs as JSON" goal:
   `ProcessKotlinDocs/` (turns Kotlin's HTML doc export into a self-contained HTML set + table of
   contents, used by `.github/workflows/automate-kotlin.yaml`), `ProcessAndroidDevSite/`, `AndroidDocs/`
@@ -180,7 +180,6 @@ isn't lost:
   (e.g. [bookshelf-plugin](https://github.com/appdevforall/bookshelf-plugin)), not by this repo.
   Not a gap to fill here.
 - `PUCC_*` tables are unrelated to documentation tooling. Ignore; leave as-is.
-- `fix/ADFA-4514` needs a rebase onto `main` before merge — noted above.
 - `docdb-studio`'s schema is expected to lag the live schema and catch up after the fact; that's
   fine, no urgent update needed.
 - `check-tools/db_health_checker.py` is not being extended with `Templates`/`Bookshelf` checks

--- a/Dokka-plugin-kdoc2json/scripts/kotlin/build-stdlib-json-docs.sh
+++ b/Dokka-plugin-kdoc2json/scripts/kotlin/build-stdlib-json-docs.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Builds the kotlin-stdlib/kotlin-test/kotlin-reflect API docs as JSON via the
+# kdoc-to-json Dokka plugin, against a full kotlin/ (https://github.com/JetBrains/kotlin)
+# repo checkout - freshly compiling and publishing the plugin from source
+# first, so every run picks up whatever's currently in
+# Dokka-plugin-kdoc2json/kdoc-to-json/src, not a jar left over from an
+# earlier run.
+#
+# Only generates the JSON output (dokkaGenerateModuleJson), not the default
+# HTML - JSON/latest/all-libs is the only thing this project's pipeline
+# (sync_kdoc_json_to_db.py) consumes. Use build-kotlin-stdlib.sh directly,
+# against libraries/tools/kotlin-stdlib-docs, if you also want the HTML
+# comparison output that test_kotlin_stdlib.sh checks against.
+#
+# The target kotlin-stdlib-docs project's build.gradle.kts is swapped out
+# for this directory's own (JSON-plugin-enabled) copy for the duration of
+# the build, then restored automatically on exit - the kotlin checkout is
+# left exactly as it was found, whether the build succeeds or fails.
+#
+# Only the final output path is written to stdout; every other message goes
+# to stderr, so this composes as:
+#   STDLIB_ALL_LIBS="$(build-stdlib-json-docs.sh <kotlin-repo-root>)"
+set -euo pipefail
+
+log() { echo "$@" >&2; }
+
+if [ $# -lt 1 ]; then
+    log "Usage: $0 <path-to-kotlin-repo-root> [output-dir]"
+    exit 1
+fi
+
+KOTLIN_ROOT="$(cd "$1" && pwd)"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PLUGIN_DIR="$(cd "$SCRIPT_DIR/../../kdoc-to-json" && pwd)"
+STDLIB_DOCS_DIR="$KOTLIN_ROOT/libraries/tools/kotlin-stdlib-docs"
+OUTPUT_ROOT="$(mkdir -p "${2:-$SCRIPT_DIR/build-output}" && cd "${2:-$SCRIPT_DIR/build-output}" && pwd)"
+JSON_OUTPUT_DIR="$OUTPUT_ROOT/json"
+
+if [ ! -f "$KOTLIN_ROOT/gradle.properties" ]; then
+    log "error: '$KOTLIN_ROOT' doesn't look like a kotlin repo checkout (missing gradle.properties)."
+    exit 1
+fi
+if [ ! -f "$STDLIB_DOCS_DIR/settings.gradle.kts" ] || [ ! -x "$STDLIB_DOCS_DIR/gradlew" ]; then
+    log "error: '$STDLIB_DOCS_DIR' doesn't look like a kotlin-stdlib-docs project (missing settings.gradle.kts or gradlew)."
+    exit 1
+fi
+if [ ! -x "$PLUGIN_DIR/gradlew" ]; then
+    log "error: kdoc-to-json plugin project not found at '$PLUGIN_DIR' (missing gradlew)."
+    exit 1
+fi
+
+# The JSON-plugin-enabled build.gradle.kts we're about to install reads
+# dokka_version as a plain Gradle project property (-Pdokka_version=...)
+# rather than through this repo's own version catalog, so it has to be
+# supplied explicitly - pulled from the same catalog entry the rest of the
+# kotlin repo's Dokka usage is pinned to, so it never drifts out of sync.
+DOKKA_VERSION="$(grep -m1 '^dokka[[:space:]]*=' "$KOTLIN_ROOT/gradle/libs.versions.toml" | sed -E 's/^dokka[[:space:]]*=[[:space:]]*"([^"]*)".*/\1/')"
+if [ -z "$DOKKA_VERSION" ]; then
+    log "error: couldn't find a 'dokka = \"...\"' entry in $KOTLIN_ROOT/gradle/libs.versions.toml"
+    exit 1
+fi
+
+log "==> [1/2] Building and publishing a fresh copy of the kdoc-to-json plugin..."
+# Sent to stderr (fd 2), not left on stdout - a caller doing
+# STDLIB_ALL_LIBS="$(build-stdlib-json-docs.sh ...)" must only capture the
+# final path this script echoes, not gradlew's own build console output.
+( cd "$PLUGIN_DIR" && ./gradlew clean publishToMavenLocal ) >&2
+
+log "==> Installing kdoc-to-json-enabled build.gradle.kts into $STDLIB_DOCS_DIR"
+ORIGINAL_BUILD_GRADLE="$(mktemp)"
+cp "$STDLIB_DOCS_DIR/build.gradle.kts" "$ORIGINAL_BUILD_GRADLE"
+restore_build_gradle() {
+    cp "$ORIGINAL_BUILD_GRADLE" "$STDLIB_DOCS_DIR/build.gradle.kts"
+    rm -f "$ORIGINAL_BUILD_GRADLE"
+}
+trap restore_build_gradle EXIT
+cp "$SCRIPT_DIR/build.gradle.kts" "$STDLIB_DOCS_DIR/build.gradle.kts"
+
+log "==> [2/2] Generating JSON documentation via kdoc-to-json (dokka $DOKKA_VERSION)..."
+# --refresh-dependencies forces Gradle to re-resolve the just-published
+# SNAPSHOT jar from mavenLocal() rather than serving a same-GAV copy it
+# cached from an earlier run of this same script.
+( cd "$STDLIB_DOCS_DIR" && ./gradlew dokkaGenerateModuleJson \
+    "-PdocsBuildDir=$JSON_OUTPUT_DIR" \
+    "-Pdokka_version=$DOKKA_VERSION" \
+    --refresh-dependencies ) >&2
+
+ALL_LIBS_DIR="$JSON_OUTPUT_DIR/latest/all-libs"
+if [ ! -d "$ALL_LIBS_DIR" ]; then
+    log "error: expected output at '$ALL_LIBS_DIR' but it wasn't created."
+    exit 1
+fi
+
+log "==> Done."
+echo "$ALL_LIBS_DIR"

--- a/Dokka-plugin-kdoc2json/scripts/kotlin/build.gradle.kts
+++ b/Dokka-plugin-kdoc2json/scripts/kotlin/build.gradle.kts
@@ -46,7 +46,14 @@ allprojects {
         // 3. Maven Central (Keep this for standard standard stable libraries like Gson/Coroutines)
         mavenCentral()
 
-        // ALL REMOTE JETBRAINS SNAPSHOT SERVERS HAVE BEEN REMOVED!
+        // 4. Dokka's own dev-snapshot server - required by plugins:dokka-samples-transformer-plugin
+        // and plugins:dokka-version-filter-plugin (both included by kotlin-stdlib-docs'
+        // settings.gradle.kts and pulled onto the build graph by its dokka-convention plugin),
+        // which pin to a Dokka dev build rather than a Maven Central release. Same property +
+        // default kotlin-stdlib-docs' own settings.gradle.kts uses, so this only ever points
+        // wherever that project already expects it to.
+        maven(url = providers.gradleProperty("dokka_repository")
+            .getOrElse("https://redirector.kotlinlang.org/maven/dokka-dev"))
     }
 
     // --- ADDED THIS EXCLUSION BLOCK ---

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/README.md
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/README.md
@@ -21,9 +21,7 @@ for anything here to run.
 
 ## Requirements
 
-- Python 3.10+
-- `pip install markdown-it-py Pillow scour brotli`
-- `cairosvg` (only needed if an optimized SVG exceeds `--svg-rasterize-threshold`): `pip install cairosvg`
+- Python 3.10+ and [`uv`](https://docs.astral.sh/uv/getting-started/installation/) — every command below is run as `uv run --with-requirements <repo-root>/requirements.txt <script>.py ...`, which installs `markdown-it-py`, `Pillow`, `scour`, `cairosvg`, `brotli`, and the rest of the repo's dependencies into an ephemeral environment; there's no separate `pip install` step.
 - `pngquant` on `PATH` (e.g. `apt install pngquant`) — required by `optimize_media.py`/`insert_optimized_media.py`, and by `populate_db.py` for the images it inserts directly from the Writerside export.
 
 `populate_db.py` also expects, relative to its own location, and already
@@ -49,14 +47,16 @@ for local inspection or a different renderer. Step 1 is `md_to_json.py`
 produces.
 
 ```bash
+UV_RUN="uv run --with-requirements ../../../requirements.txt"
+
 # 1. Convert every topic .md into JSON, one file per page (ADFA-5039)
-python3 md_to_json.py <docs-root> <output-dir> config.json
+$UV_RUN md_to_json.py <docs-root> <output-dir> config.json
 
 # 2. Build the sidebar nav from kr.tree against that JSON output
-python3 build_nav.py <docs-root> <output-dir> <output-dir>
+$UV_RUN build_nav.py <docs-root> <output-dir> <output-dir>
 
 # 3. (optional) Check for broken links/images/includes in the source tree
-python3 find_missing_assets.py <docs-root> missing-assets-report.md
+$UV_RUN find_missing_assets.py <docs-root> missing-assets-report.md
 ```
 
 `<output-dir>` ends up containing everything `md_to_json.py` writes, plus:
@@ -69,7 +69,7 @@ the same conversion as `md_to_json.py`/`build_nav.py` internally — you don't
 run those scripts first.
 
 ```bash
-python3 populate_db.py <docs-root> config.json <webHelpImages.zip> [db-path]
+uv run --with-requirements ../../../requirements.txt populate_db.py <docs-root> config.json <webHelpImages.zip> [db-path]
 ```
 
 - `db-path` defaults to `documentation.db` in the current directory, and must already exist with the expected schema (`Languages`, `ContentTypes`, `Templates` tables populated).
@@ -87,7 +87,8 @@ illustrative only — open `<docs-root>/kr.tree` and copy the actual
 `toc-title` chain for whatever section you're dropping (e.g. Kotlin/Wasm):
 
 ```bash
-python3 populate_db.py <docs-root> config.json <webHelpImages.zip> documentation.db \
+uv run --with-requirements ../../../requirements.txt populate_db.py \
+  <docs-root> config.json <webHelpImages.zip> documentation.db \
   --blacklisted-element-titles \
     "<Top-Level Title>\/<Nested Title>"
 ```
@@ -106,13 +107,13 @@ Two options, depending on whether the database already has pages loaded:
 **Standalone optimization only** (no database involved):
 
 ```bash
-python3 optimize_media.py <input-dir> <output-dir> [--max-width 500] [--webp] [...]
+uv run --with-requirements ../../../requirements.txt optimize_media.py <input-dir> <output-dir> [--max-width 500] [--webp] [...]
 ```
 
 **Optimize and update an existing database's images in place:**
 
 ```bash
-python3 insert_optimized_media.py <media-dir> <db-path> [work-dir] [options]
+uv run --with-requirements ../../../requirements.txt insert_optimized_media.py <media-dir> <db-path> [work-dir] [options]
 ```
 
 This re-runs `optimize_media.py`'s pipeline, backs up the database first,

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/README.md
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/README.md
@@ -1,0 +1,133 @@
+# Process Kotlin Website JSON
+
+Scripts for loading converted Kotlin website JSON, its navigation tree, and
+its media straight into a `documentation.db`-schema SQLite database.
+
+The JSON conversion itself (`md_to_json.py`) is a separate ticket/PR
+(ADFA-5039); `build_nav.py` and `populate_db.py` below import it directly,
+so it needs to already be merged (or otherwise present in this directory)
+for anything here to run.
+
+## Scripts
+
+| Script | Purpose |
+|---|---|
+| `md_to_json.py` (ADFA-5039, not in this PR) | Converts every `topics/**/*.md` page into one JSON file. Writes `theme.json` and copies `images/` into the output directory. See that ticket's README for the page JSON schema. |
+| [`build_nav.py`](build_nav.py) | Builds `nav.json`/`nav.html` sidebar navigation from `kr.tree`, resolving each `<toc-element topic="...">` against `md_to_json.py`'s output. |
+| [`find_missing_assets.py`](find_missing_assets.py) | QA pass: reports cross-page links, images, and `<include>` targets in the source tree that don't resolve to anything. Reuses `md_to_json.py`'s own resolution logic, so it flags exactly what would end up broken on the rendered site. |
+| [`populate_db.py`](populate_db.py) | The database path: converts the docs tree the same way `md_to_json.py` does, builds nav the same way `build_nav.py` does, and inserts pages + nav + images + CSS/JS directly into `documentation.db` (replacing everything under `k/html/` and `assets/`). Supports pruning whole `kr.tree` subtrees via `--blacklisted-element-titles`. |
+| [`optimize_media.py`](optimize_media.py) | Standalone media optimizer: downscales/recompresses a directory of images (pngquant, Pillow, Scour/cairosvg for SVG) into a mirrored output directory. |
+| [`insert_optimized_media.py`](insert_optimized_media.py) | Runs `optimize_media.py`'s pipeline over a directory of raw media, then replaces the corresponding `k/html/images/*` rows in an existing database, rewriting any page that referenced a renamed file and deleting anything left unreferenced. |
+
+## Requirements
+
+- Python 3.10+
+- `pip install markdown-it-py Pillow scour brotli`
+- `cairosvg` (only needed if an optimized SVG exceeds `--svg-rasterize-threshold`): `pip install cairosvg`
+- `pngquant` on `PATH` (e.g. `apt install pngquant`) — required by `optimize_media.py`/`insert_optimized_media.py`, and by `populate_db.py` for the images it inserts directly from the Writerside export.
+
+`populate_db.py` also expects, relative to its own location, and already
+included in this directory:
+
+- `templates/page.peb`, `templates/nav.peb` — Pebble templates upserted into the `Templates` table.
+- `assets/docs.css`, `assets/tabs.js`, `assets/sidebar.js` — static assets inserted at `assets/<name>`.
+
+## Inputs you need before starting
+
+- A checkout of `kotlin-web-site/docs` (the `<docs-root>` argument below) — contains `topics/`, `images/`, `v.list`, and `kr.tree`.
+- A config JSON with theming colors, e.g.:
+  ```json
+  {"broken-ext-link-color": "#cc0000", "menu-no-link-color": "#999999"}
+  ```
+- Writerside's own image export zip (e.g. `webHelpImages.zip`, found next to `kr.tree`) if you're using `populate_db.py`.
+
+## Workflow: generate JSON + nav for a static/templated preview
+
+Use this to produce standalone JSON pages and nav data (not the database)
+for local inspection or a different renderer. Step 1 is `md_to_json.py`
+(ADFA-5039) — see that ticket for its own usage and the page JSON schema it
+produces.
+
+```bash
+# 1. Convert every topic .md into JSON, one file per page (ADFA-5039)
+python3 md_to_json.py <docs-root> <output-dir> config.json
+
+# 2. Build the sidebar nav from kr.tree against that JSON output
+python3 build_nav.py <docs-root> <output-dir> <output-dir>
+
+# 3. (optional) Check for broken links/images/includes in the source tree
+python3 find_missing_assets.py <docs-root> missing-assets-report.md
+```
+
+`<output-dir>` ends up containing everything `md_to_json.py` writes, plus:
+- `nav.json` / `nav.html` — sidebar tree and a pre-rendered static copy
+
+## Workflow: generate + insert directly into the documentation database
+
+This is the path that actually populates `documentation.db`. It performs
+the same conversion as `md_to_json.py`/`build_nav.py` internally — you don't
+run those scripts first.
+
+```bash
+python3 populate_db.py <docs-root> config.json <webHelpImages.zip> [db-path]
+```
+
+- `db-path` defaults to `documentation.db` in the current directory, and must already exist with the expected schema (`Languages`, `ContentTypes`, `Templates` tables populated).
+- A timestamped backup (`<db-path>.backup-<timestamp>`) is written before any changes, via SQLite's `VACUUM INTO`.
+- Everything under `k/html/` and `assets/` is deleted and re-inserted in a single transaction (rolled back on error), then the database is `VACUUM`ed.
+
+### Pruning documentation you don't want (ADFA-4737)
+
+To leave a whole `kr.tree` subtree out of the database entirely — nav
+entry, converted pages, and all — pass `--blacklisted-element-titles` with
+the full `toc-title` path from a top-level element down to the one you want
+to drop. Levels are joined with `\/` (backslash-slash), not a bare `/`,
+since a bare `/` commonly appears inside a real title. The example below is
+illustrative only — open `<docs-root>/kr.tree` and copy the actual
+`toc-title` chain for whatever section you're dropping (e.g. Kotlin/Wasm):
+
+```bash
+python3 populate_db.py <docs-root> config.json <webHelpImages.zip> documentation.db \
+  --blacklisted-element-titles \
+    "<Top-Level Title>\/<Nested Title>"
+```
+
+Any other page's in-content link to a pruned topic renders as a styled
+"broken" link (via `broken-ext-link-color`) rather than a dead link with no
+indication anything changed. Run with `--blacklisted-element-titles` first
+against a scratch copy of the database and check the warnings on stderr for
+any path that didn't match — that usually means the toc-title or ancestor
+chain was copied wrong.
+
+## Workflow: optimizing and inserting media
+
+Two options, depending on whether the database already has pages loaded:
+
+**Standalone optimization only** (no database involved):
+
+```bash
+python3 optimize_media.py <input-dir> <output-dir> [--max-width 500] [--webp] [...]
+```
+
+**Optimize and update an existing database's images in place:**
+
+```bash
+python3 insert_optimized_media.py <media-dir> <db-path> [work-dir] [options]
+```
+
+This re-runs `optimize_media.py`'s pipeline, backs up the database first,
+replaces each `k/html/images/<name>` row with the optimized bytes, rewrites
+any page/nav reference to a file that got renamed during optimization (e.g.
+`--webp` conversion or SVG rasterization), and deletes any image no page
+references anymore. Both scripts share the same tuning flags
+(`--max-width`, `--jpeg-quality`, `--webp`, `--webp-quality`,
+`--pngquant-speed`, `--svg-precision`, `--svg-rasterize-threshold`,
+`--verbose`, `--log-file`), settable via `--config <file>` instead of the
+command line — see either script's module docstring for the full option
+reference.
+
+## Recommended order for a full refresh
+
+1. `find_missing_assets.py` against the new `<docs-root>` — fix anything broken in the source before converting it.
+2. `populate_db.py`, with `--blacklisted-element-titles` for anything you don't want documented (e.g. Kotlin/Wasm per ADFA-4737).
+3. `insert_optimized_media.py` against the raw media directory, if you want optimized (resized/compressed) images rather than Writerside's own export as-is.

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/assets/docs.css
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/assets/docs.css
@@ -90,6 +90,14 @@ html, body {
   display: none;
 }
 
+/* nav.peb emits this for nodes kr.tree marks hidden (Writerside's own
+   "hide from primary nav" flag) - without this rule the class was inert
+   and every hidden entry (e.g. individual Kotlin tour steps) rendered
+   identically to a normal one. */
+.nav-hidden {
+  display: none;
+}
+
 .nav-item.nav-expanded > .nav-subtree {
   display: block;
 }

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/assets/docs.css
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/assets/docs.css
@@ -1,0 +1,227 @@
+html, body {
+  background: #ffffff;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+.docs-layout {
+  display: flex;
+  align-items: flex-start;
+}
+
+.docs-sidebar {
+  width: 280px;
+  flex-shrink: 0;
+  box-sizing: border-box;
+  overflow-y: auto;
+  max-height: 100vh;
+  position: sticky;
+  top: 0;
+}
+
+.docs-content {
+  flex: 1;
+  min-width: 0;
+  padding: 0 24px;
+}
+
+/* Source images/videos carry explicit width="..." attributes (from
+   Writerside's `{width="800"}` sizing hints, see md_to_json.py), which is an
+   intrinsic pixel size the img/video would otherwise render at even when
+   that's wider than the viewport. max-width: 100% lets it shrink to fit
+   instead of overflowing on narrow screens, while height: auto keeps its
+   aspect ratio as it scales down. */
+.docs-content img,
+.docs-content video,
+.docs-content iframe {
+  max-width: 100%;
+  height: auto;
+}
+
+/* Long code lines can't shrink like an image can without breaking the code's
+   formatting, so let the block itself scroll horizontally instead - without
+   this the unconstrained width pushes out past the viewport and the whole
+   page grows a horizontal scrollbar on narrow screens. */
+.docs-content pre.code-block {
+  overflow-x: auto;
+  box-sizing: border-box;
+  max-width: 100%;
+}
+
+/* Sidebar tree: <ul>/<li> are only used for their document structure here,
+   not as a bulleted list, so strip the browser's default marker/indent/
+   margin on every level (root .nav-tree and each nested .nav-subtree share
+   the class) and build indentation and disclosure icons ourselves below. */
+.docs-nav {
+  font-size: 14px;
+  line-height: 1.4;
+  color: #333333;
+}
+
+.docs-nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.docs-nav .nav-subtree {
+  padding-left: 14px;
+}
+
+/* Per-topic collapse/expand (nav.peb: every node with children renders a
+   sibling .nav-toggle-group button next to its label/link, leaf nodes render
+   a same-sized .nav-spacer instead so labels still line up in a column).
+   Collapsed is the CSS default so the tree stays usable without JS;
+   assets/sidebar.js toggles .nav-expanded on click and auto-expands the
+   current page's ancestors. */
+.nav-row {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  cursor: default;
+}
+
+.nav-row:hover {
+  background: #f0f1f2;
+}
+
+.nav-item > .nav-subtree {
+  display: none;
+}
+
+.nav-item.nav-expanded > .nav-subtree {
+  display: block;
+}
+
+.nav-toggle-group,
+.nav-spacer {
+  width: 14px;
+  height: 14px;
+  flex-shrink: 0;
+}
+
+.nav-toggle-group {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  color: #666666;
+}
+
+.nav-toggle-group::before {
+  content: "\25B8"; /* ▸ */
+  display: inline-block;
+  font-size: 10px;
+  transition: transform 0.15s ease;
+}
+
+.nav-item.nav-expanded > .nav-row > .nav-toggle-group::before {
+  transform: rotate(90deg);
+}
+
+.nav-link,
+.nav-group-title {
+  flex: 1;
+  min-width: 0;
+  padding: 2px 0;
+  color: inherit;
+  text-decoration: none;
+}
+
+.nav-link:hover {
+  text-decoration: underline;
+}
+
+.nav-group-title {
+  cursor: default;
+}
+
+.nav-link--active {
+  font-weight: 700;
+  color: #0b57d0;
+}
+
+.nav-item--current > .nav-row {
+  background: #e8f0fe;
+  border-left: 3px solid #0b57d0;
+  padding-left: 5px; /* 8px base padding - 3px border, so text doesn't shift */
+}
+
+/* Mobile off-canvas drawer (assets/sidebar.js: hamburger button, backdrop,
+   and edge-swipe open/close all toggle the classes below). Above the
+   breakpoint the sidebar stays a normal static column and these are inert. */
+.nav-toggle {
+  display: none;
+}
+
+.nav-backdrop {
+  display: none;
+}
+
+@media (max-width: 900px) {
+  .docs-layout {
+    display: block;
+  }
+
+  .nav-toggle {
+    display: block;
+    position: fixed;
+    top: 10px;
+    left: 10px;
+    z-index: 1001;
+    width: 40px;
+    height: 40px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+    background: #ffffff;
+  }
+
+  .nav-toggle::before {
+    content: "\2630"; /* ☰ */
+    font-size: 1.3em;
+  }
+
+  .docs-sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
+    max-height: 100%;
+    width: 85vw;
+    max-width: 320px;
+    background: #ffffff;
+    z-index: 1000;
+    box-shadow: 2px 0 12px rgba(0, 0, 0, 0.25);
+    transform: translateX(-100%);
+    transition: transform 0.25s ease;
+    padding-top: 56px;
+  }
+
+  .docs-sidebar.sidebar-open {
+    transform: translateX(0);
+  }
+
+  .nav-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.25s ease;
+    z-index: 999;
+  }
+
+  .nav-backdrop--visible {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .docs-content {
+    padding-top: 56px;
+  }
+}

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/assets/sidebar.js
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/assets/sidebar.js
@@ -1,0 +1,172 @@
+// Drives the sidebar templates/nav.peb renders: the mobile off-canvas drawer
+// (hamburger button, backdrop, edge swipe-to-open / swipe-to-close) and the
+// per-topic collapse/expand toggles (.nav-toggle-group, one per node with
+// children). Also auto-expands and highlights whichever nav-link matches the
+// current page on load, so a reader landing deep in the tree doesn't see an
+// entirely collapsed sidebar with no indication of where they are.
+(function () {
+  var sidebar = document.getElementById("sidebar");
+  if (!sidebar) return;
+
+  var menuButton = document.getElementById("nav-toggle");
+  var backdrop = document.getElementById("nav-backdrop");
+  var MOBILE_QUERY = "(max-width: 900px)";
+
+  function isMobile() {
+    return window.matchMedia && window.matchMedia(MOBILE_QUERY).matches;
+  }
+
+  function openSidebar() {
+    sidebar.classList.add("sidebar-open");
+    if (backdrop) backdrop.classList.add("nav-backdrop--visible");
+    if (menuButton) menuButton.setAttribute("aria-expanded", "true");
+  }
+
+  function closeSidebar() {
+    sidebar.classList.remove("sidebar-open");
+    if (backdrop) backdrop.classList.remove("nav-backdrop--visible");
+    if (menuButton) menuButton.setAttribute("aria-expanded", "false");
+  }
+
+  function toggleSidebar() {
+    if (sidebar.classList.contains("sidebar-open")) {
+      closeSidebar();
+    } else {
+      openSidebar();
+    }
+  }
+
+  if (menuButton) menuButton.addEventListener("click", toggleSidebar);
+  if (backdrop) backdrop.addEventListener("click", closeSidebar);
+
+  function toggleItem(item) {
+    var toggle = item.querySelector(":scope > .nav-row > .nav-toggle-group");
+    var expanded = item.classList.toggle("nav-expanded");
+    if (toggle) toggle.setAttribute("aria-expanded", expanded ? "true" : "false");
+  }
+
+  // Per-topic collapse/expand: every node with children renders a sibling
+  // .nav-toggle-group button next to its label/link (see nav.peb) so this
+  // never has to guess which <li> a click landed in beyond closest(). A
+  // group header with no page of its own (.nav-group-title, not a link) also
+  // toggles on click, since clicking it can't navigate anywhere anyway.
+  sidebar.addEventListener("click", function (event) {
+    var toggle = event.target.closest(".nav-toggle-group");
+    if (toggle) {
+      toggleItem(toggle.closest(".nav-item"));
+      return;
+    }
+    var groupTitle = event.target.closest(".nav-group-title");
+    if (groupTitle) {
+      toggleItem(groupTitle.closest(".nav-item"));
+      return;
+    }
+    // Navigating on mobile should close the drawer instead of leaving it
+    // covering the page the reader just opened.
+    if (event.target.closest(".nav-link") && isMobile()) {
+      closeSidebar();
+    }
+  });
+
+  function expandAncestors(item) {
+    while (item) {
+      item.classList.add("nav-expanded");
+      var toggle = item.querySelector(":scope > .nav-row > .nav-toggle-group");
+      if (toggle) toggle.setAttribute("aria-expanded", "true");
+      var parentList = item.parentElement;
+      item = parentList ? parentList.closest(".nav-item") : null;
+    }
+  }
+
+  // Scrolls only the sidebar's own internal scrollbox to reveal el, without
+  // touching window scroll - the sidebar is position:fixed on mobile (and
+  // translated off-canvas until opened), so a plain el.scrollIntoView()
+  // would have the browser scroll the whole page trying to "reveal" an
+  // element that fixed positioning makes it unable to actually bring into
+  // view that way.
+  function scrollWithinSidebar(el) {
+    var elRect = el.getBoundingClientRect();
+    var boxRect = sidebar.getBoundingClientRect();
+    sidebar.scrollTop += elRect.top - boxRect.top - sidebar.clientHeight / 2;
+  }
+
+  function highlightCurrentPage() {
+    var path = window.location.pathname.replace(/^\//, "").replace(/\.html$/, "");
+    var current = sidebar.querySelector('.nav-link[data-nav-id="' + path + '"]');
+    if (!current) return;
+    current.classList.add("nav-link--active");
+    current.setAttribute("aria-current", "page");
+    current.closest(".nav-item").classList.add("nav-item--current");
+    expandAncestors(current.closest(".nav-item"));
+    scrollWithinSidebar(current);
+  }
+
+  // The static-site pipeline (RenderDocs.java) has page.peb include a
+  // pre-rendered nav.html at request/build time, so the sidebar already has
+  // its content by the time this script runs. The database-backed server
+  // has no such file-based template include (see layout.pebble - templates
+  // there are fully self-contained), so its page template instead renders
+  // <aside id="sidebar" data-nav-src="..."></aside> empty and expects the
+  // client to fetch and inject the nav markup itself. Handle both the same
+  // way: run the content-dependent init once the markup actually exists.
+  var navSrc = sidebar.getAttribute("data-nav-src");
+  if (navSrc) {
+    fetch(navSrc)
+      .then(function (response) {
+        return response.text();
+      })
+      .then(function (html) {
+        sidebar.insertAdjacentHTML("beforeend", html);
+        highlightCurrentPage();
+      })
+      .catch(function (err) {
+        console.error("Failed to load navigation from " + navSrc + ":", err);
+      });
+  } else {
+    highlightCurrentPage();
+  }
+
+  // Edge swipe-right opens the drawer, swipe-left (anywhere) closes it.
+  var touchStartX = null;
+  var touchStartY = null;
+  var EDGE_ZONE = 24;
+  var SWIPE_THRESHOLD = 60;
+
+  document.addEventListener(
+    "touchstart",
+    function (event) {
+      var t = event.touches[0];
+      touchStartX = t.clientX;
+      touchStartY = t.clientY;
+    },
+    { passive: true }
+  );
+
+  document.addEventListener(
+    "touchend",
+    function (event) {
+      if (touchStartX === null || !isMobile()) {
+        touchStartX = null;
+        touchStartY = null;
+        return;
+      }
+      var startX = touchStartX;
+      var startY = touchStartY;
+      touchStartX = null;
+      touchStartY = null;
+
+      var t = event.changedTouches[0];
+      var dx = t.clientX - startX;
+      var dy = t.clientY - startY;
+      if (Math.abs(dx) < SWIPE_THRESHOLD || Math.abs(dx) < Math.abs(dy)) return;
+
+      var isOpen = sidebar.classList.contains("sidebar-open");
+      if (!isOpen && dx > 0 && startX <= EDGE_ZONE) {
+        openSidebar();
+      } else if (isOpen && dx < 0) {
+        closeSidebar();
+      }
+    },
+    { passive: true }
+  );
+})();

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/assets/tabs.js
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/assets/tabs.js
@@ -1,0 +1,71 @@
+// Makes the <div class="tabs">...</div> blocks page.peb renders (for
+// md_to_json.py's "tabs" block type) switchable, including linking every
+// tabs block that shares the same data-group on a page - e.g. picking
+// "Groovy" in one Kotlin/Groovy/Maven build-script tabs block switches every
+// other build-script tabs block on the page - and remembering the choice
+// across pages via localStorage, mirroring Writerside's data-sync-tabs.
+(function () {
+  var STORAGE_PREFIX = "docs-tab-group:";
+
+  function activate(container, groupKey) {
+    var buttons = container.querySelectorAll(".tab-button");
+    var panels = container.querySelectorAll(".tab-panel");
+    var hasMatch = false;
+    for (var i = 0; i < buttons.length; i++) {
+      if (buttons[i].dataset.groupKey === groupKey) {
+        hasMatch = true;
+        break;
+      }
+    }
+    if (!hasMatch) return;
+
+    buttons.forEach(function (btn) {
+      var active = btn.dataset.groupKey === groupKey;
+      btn.classList.toggle("tab-button--active", active);
+      btn.setAttribute("aria-selected", active ? "true" : "false");
+    });
+    panels.forEach(function (panel) {
+      var active = panel.dataset.groupKey === groupKey;
+      panel.classList.toggle("tab-panel--active", active);
+      panel.hidden = !active;
+    });
+  }
+
+  function switchGroup(group, groupKey) {
+    document.querySelectorAll('.tabs[data-group="' + group + '"]').forEach(function (container) {
+      activate(container, groupKey);
+    });
+    try {
+      localStorage.setItem(STORAGE_PREFIX + group, groupKey);
+    } catch (e) {
+      // localStorage unavailable (private browsing, etc.) - selection just won't persist.
+    }
+  }
+
+  document.addEventListener("click", function (event) {
+    var button = event.target.closest(".tab-button");
+    if (!button) return;
+    var container = button.closest(".tabs");
+    if (!container) return;
+    var groupKey = button.dataset.groupKey;
+    var group = container.dataset.group;
+    if (group) {
+      switchGroup(group, groupKey);
+    } else {
+      activate(container, groupKey);
+    }
+  });
+
+  document.addEventListener("DOMContentLoaded", function () {
+    document.querySelectorAll(".tabs[data-group]").forEach(function (container) {
+      var group = container.dataset.group;
+      var saved = null;
+      try {
+        saved = localStorage.getItem(STORAGE_PREFIX + group);
+      } catch (e) {
+        // ignore
+      }
+      if (saved) activate(container, saved);
+    });
+  });
+})();

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/build_nav.py
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/build_nav.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""
+Builds sidebar navigation data/HTML from a JetBrains Writerside .tree file
+(e.g. kotlin-web-site/docs/kr.tree), for use with templates/nav.peb.
+
+Usage:
+    python3 build_nav.py <docs-root> <docs-json-dir> <output-dir> [--tree-file kr.tree]
+
+<docs-root>      is the checkout of kotlin-web-site/docs (contains kr.tree).
+<docs-json-dir>  is the output of md_to_json.py, used to resolve each
+                  <toc-element topic="foo.md"/> to the page's "id" (its path
+                  relative to docs-root, e.g. "topics/ksp/ksp-overview") and,
+                  when a <toc-element> has no toc-title, its rendered "title".
+<output-dir>     receives nav.json (the tree, for feeding into nav.peb) and
+                  nav.html (a pre-rendered static copy of what nav.peb outputs).
+
+Writerside lets a <toc-element> both link to its own page (topic="...") and
+contain nested <toc-element> children (sub-pages) at once, and topic
+references are bare filenames resolved by uniqueness across the whole
+topics/ subtree, not by path - this script relies on that same uniqueness.
+
+A topic="foo.md" that doesn't resolve to any converted page is treated as
+manually deleted (rather than e.g. a typo) and dropped from the nav: if the
+toc-element has no children either, build_node() returns None for it and it's
+filtered out of its parent's children entirely; if it still has children
+(sub-topics that do still exist), the element is kept as a link-less category
+header for them instead of losing those children too. This only applies to
+topic="*.md" references - kr.tree itself is never modified, so a purged
+topic's <toc-element> (and any of its still-live children) stays in the tree
+forever; this is what re-derives "not actually present" from the docs-json
+output on every run instead.
+
+If <docs-json-dir>/theme.json (written by md_to_json.py from its own config
+argument) has a "menu-no-link-color", each node that doesn't actually lead to
+a generated page - a pure category header with no topic="...", a
+topic="foo.topic" that isn't a converted .md page (e.g. home.topic,
+api-references.topic), or a topic="foo.md" whose page was deleted but which
+still has live children - gets a "noLinkColor" of that value baked directly
+into its entry in nav.json (null otherwise), which nav.peb turns into an
+inline style. A toc-element using kr.tree's other, unrelated href="https://..."
+attribute (e.g. "Test library (kotlin.test)" under API reference) is not
+treated any differently here - it has no topic="...", so it's already a
+no-link category header like any other; this script does not read that
+external href at all, so no link is added for it.
+"""
+import argparse
+import json
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+HUMANIZE_RE = re.compile(r"[-_]+")
+
+
+def humanize(stem: str) -> str:
+    return HUMANIZE_RE.sub(" ", stem).strip().title()
+
+
+def load_page_index(docs_json_dir: Path) -> tuple[dict, dict]:
+    """Returns (stem -> id, id -> title) built from every generated page JSON."""
+    stem_to_id = {}
+    id_to_title = {}
+    for json_path in docs_json_dir.rglob("*.json"):
+        page = json.loads(json_path.read_text(encoding="utf-8"))
+        page_id = page.get("id")
+        if not page_id:
+            continue
+        stem = Path(page_id).name
+        stem_to_id[stem] = page_id
+        id_to_title[page_id] = page.get("title")
+    return stem_to_id, id_to_title
+
+
+def build_node(el: ET.Element, stem_to_id: dict, id_to_title: dict, warnings: list, no_link_color: str,
+               id_prefix: str = "") -> dict | None:
+    """Returns None when this element's own topic="*.md" no longer resolves
+    to a converted page (deleted) and it has no children left worth keeping -
+    callers must filter these out of whatever list they collect build_node()
+    results into (both build_node() itself, for its own children, and the
+    top-level toc-element loop in main())."""
+    topic = el.get("topic")
+    toc_title = el.get("toc-title")
+    hidden = el.get("hidden") == "true"
+
+    children = [
+        build_node(c, stem_to_id, id_to_title, warnings, no_link_color, id_prefix)
+        for c in el.findall("toc-element")
+    ]
+    children = [c for c in children if c is not None]
+
+    page_id = None
+    title = toc_title
+    no_link = True
+    deleted = False
+    if topic:
+        stem = Path(topic).stem
+        page_id = stem_to_id.get(stem)
+        if page_id is None:
+            if topic.endswith(".md"):
+                # Was a real page at some point, isn't anymore - the .md was
+                # manually deleted. Drop this node; if children still resolve
+                # to real pages, keep it around as a no-link category header
+                # for them rather than losing those children too.
+                deleted = True
+                if children:
+                    warnings.append(f"topic={topic!r} has no converted page (deleted); "
+                                     f"keeping as a header for its {len(children)} remaining child page(s)")
+                else:
+                    warnings.append(f"topic={topic!r} has no converted page (deleted); dropping from nav")
+                    return None
+            else:
+                # Not a converted .md page (e.g. home.topic, api-references.topic):
+                # still rendered as a link (for consistency, and it's still the
+                # best URL guess) but it doesn't lead anywhere real, so it's
+                # colored the same as a no-topic-at-all category header. Prefixed
+                # the same way as a resolved stem_to_id hit would be (e.g.
+                # populate_db.py passes id_prefix="k/html/" since stem_to_id
+                # there already maps every real page to "k/html/<stem>"), so
+                # this fallback id follows the same URL convention as everything
+                # else on the page rather than silently reverting to a bare one.
+                page_id = f"{id_prefix}{stem}"
+                warnings.append(f"no converted page for topic={topic!r}; using id={page_id!r}")
+        else:
+            no_link = False
+        if not title:
+            title = (id_to_title.get(page_id) if page_id else None) or humanize(stem)
+    elif not title:
+        title = "Untitled"
+
+    return {
+        "title": title,
+        "id": None if deleted else page_id,
+        "hidden": hidden,
+        "noLinkColor": no_link_color if (no_link or deleted) else None,
+        "children": children,
+    }
+
+
+def render_node(node: dict, indent: int = 0) -> str:
+    # Kept byte-identical to templates/nav.peb's renderNavNode macro, since
+    # RenderDocs.java re-renders nav.peb over nav.json for the live site and
+    # this function only produces a standalone preview copy of the same HTML.
+    classes = "nav-item" + (" nav-hidden" if node["hidden"] else "")
+    has_children = bool(node["children"])
+    style = f' style="color: {node["noLinkColor"]};"' if node["noLinkColor"] else ""
+    if node["id"]:
+        label = f'<a class="nav-link"{style} href="/{node["id"]}.html" data-nav-id="{node["id"]}">{node["title"]}</a>'
+    else:
+        label = f'<span class="nav-group-title"{style}>{node["title"]}</span>'
+    toggle = (
+        f'<button type="button" class="nav-toggle-group" aria-expanded="false" '
+        f'aria-label="Toggle {node["title"]} section"></button>'
+        if has_children else '<span class="nav-spacer" aria-hidden="true"></span>'
+    )
+    parts = [f'<li class="{classes}">', '<div class="nav-row">', toggle, label, "</div>"]
+    if has_children:
+        parts.append('<ul class="nav-tree nav-subtree">')
+        for child in node["children"]:
+            parts.append(render_node(child))
+        parts.append("</ul>")
+    parts.append("</li>")
+    return "".join(parts)
+
+
+def render_html(tree: list) -> str:
+    body = "".join(render_node(node) for node in tree)
+    return (
+        '<nav class="docs-nav" aria-label="Documentation">'
+        f'<ul class="nav-tree">{body}</ul>'
+        "</nav>"
+    )
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("docs_root", type=Path, help="Path to kotlin-web-site/docs")
+    parser.add_argument("docs_json_dir", type=Path, help="Path to md_to_json.py output directory")
+    parser.add_argument("output_dir", type=Path, help="Directory to write nav.json and nav.html into")
+    parser.add_argument("--tree-file", default="kr.tree", help="Filename of the Writerside tree file under docs_root")
+    args = parser.parse_args()
+
+    tree_path = args.docs_root / args.tree_file
+    if not tree_path.is_file():
+        print(f"error: {tree_path} does not exist", file=sys.stderr)
+        sys.exit(1)
+
+    stem_to_id, id_to_title = load_page_index(args.docs_json_dir)
+
+    theme_path = args.docs_json_dir / "theme.json"
+    no_link_color = None
+    if theme_path.is_file():
+        no_link_color = json.loads(theme_path.read_text(encoding="utf-8")).get("menu-no-link-color")
+    else:
+        print(f"warning: {theme_path} not found (run md_to_json.py first); "
+              f"no-link menu items won't be colored", file=sys.stderr)
+
+    root = ET.parse(tree_path).getroot()
+    warnings = []
+    nav_tree = [build_node(el, stem_to_id, id_to_title, warnings, no_link_color) for el in root.findall("toc-element")]
+    nav_tree = [node for node in nav_tree if node is not None]
+
+    for w in warnings:
+        print(f"warning: {w}", file=sys.stderr)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    (args.output_dir / "nav.json").write_text(
+        json.dumps(nav_tree, separators=(",", ":"), ensure_ascii=False), encoding="utf-8"
+    )
+    (args.output_dir / "nav.html").write_text(render_html(nav_tree), encoding="utf-8")
+
+    print(f"Wrote nav.json and nav.html ({len(warnings)} warning(s)) into {args.output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/find_missing_assets.py
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/find_missing_assets.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""
+Documents every reference in the docs source (kotlin-web-site/docs) that
+points at an asset - another topic page, an image, or an <include> target -
+which doesn't actually exist, so broken source content can be found and
+fixed without having to read every generated page.
+
+Usage:
+    python3 find_missing_assets.py <docs-root> [report-path] [--topics-subdir topics] [--images-subdir images]
+
+Reuses md_to_json.py's own link/image resolution (build_topic_index,
+build_image_index, Converter) instead of re-parsing links with regexes, so
+this reports exactly what would end up broken in the rendered site - e.g. a
+"foo.md" written inside a fenced code sample (showing readers what Writerside
+markup looks like) is correctly ignored, since it's never tokenized as a
+real link in the first place.
+
+<include from="..." element-id="...">  targets are a separate check: those
+aren't links/images so md_to_json.py's Converter never resolves them, but a
+missing include is still a broken asset reference worth surfacing. This is
+checked with a small standalone regex scan (fenced code blocks stripped
+first) against every filename that exists anywhere under <topics-subdir>/,
+regardless of extension (include targets can be ".md" or ".topic").
+"""
+import argparse
+import re
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+from md_to_json import Converter, build_image_index, build_topic_index, load_variables, make_markdown_it
+
+INCLUDE_RE = re.compile(r'<include\b[^>]*\bfrom\s*=\s*"([^"]+)"')
+FENCE_RE = re.compile(r"```.*?```", re.S)
+
+
+def find_include_warnings(topics_dir: Path) -> list:
+    all_filenames = {p.name for p in topics_dir.rglob("*") if p.is_file()}
+    warnings = []
+    for md_path in sorted(topics_dir.rglob("*.md")):
+        text_no_fences = FENCE_RE.sub("", md_path.read_text(encoding="utf-8"))
+        source_rel = str(md_path.relative_to(topics_dir.parent))
+        for target in INCLUDE_RE.findall(text_no_fences):
+            if target not in all_filenames:
+                warnings.append({"kind": "include", "source": source_rel, "reference": target})
+    return warnings
+
+
+def group_by_reference(warnings: list) -> dict:
+    grouped = defaultdict(set)
+    for w in warnings:
+        grouped[w["reference"]].add(w["source"])
+    return {ref: sorted(sources) for ref, sources in sorted(grouped.items())}
+
+
+def render_section(title: str, grouped: dict) -> str:
+    lines = [f"## {title} ({len(grouped)})", ""]
+    if not grouped:
+        lines.append("None.")
+    for ref, sources in grouped.items():
+        lines.append(f"- `{ref}`")
+        for src in sources:
+            lines.append(f"  - {src}")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("docs_root", type=Path, help="Path to kotlin-web-site/docs")
+    parser.add_argument("report_path", type=Path, nargs="?", default=Path("missing-assets-report.md"),
+                         help="Where to write the Markdown report (default: ./missing-assets-report.md)")
+    parser.add_argument("--topics-subdir", default="topics", help="Subdirectory of docs_root holding .md files")
+    parser.add_argument("--images-subdir", default="images", help="Subdirectory of docs_root holding image files")
+    args = parser.parse_args()
+
+    docs_root: Path = args.docs_root
+    topics_dir = docs_root / args.topics_subdir
+    images_dir = docs_root / args.images_subdir
+    if not topics_dir.is_dir():
+        print(f"error: {topics_dir} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    variables = load_variables(docs_root)
+    topic_index = build_topic_index(topics_dir)
+    image_index, image_collisions = build_image_index(images_dir)
+    md = make_markdown_it()
+    converter = Converter(md, variables, topic_index, image_index)
+
+    md_files = sorted(topics_dir.rglob("*.md"))
+    for md_path in md_files:
+        rel = md_path.relative_to(topics_dir)
+        page_id = str(rel.with_suffix(""))
+        source_rel = str(Path(args.topics_subdir) / rel)
+        try:
+            converter.convert_file(md_path, page_id, source_rel)
+        except Exception as exc:  # noqa: BLE001 - surface which file broke, keep auditing the rest
+            print(f"error scanning {md_path}: {exc}", file=sys.stderr)
+
+    link_warnings = [w for w in converter.warnings if w["kind"] == "link"]
+    image_warnings = [w for w in converter.warnings if w["kind"] == "image"]
+    include_warnings = find_include_warnings(topics_dir)
+
+    links = group_by_reference(link_warnings)
+    images = group_by_reference(image_warnings)
+    includes = group_by_reference(include_warnings)
+    collisions = {name: rels for name, rels in image_collisions}
+
+    report = [
+        "# Missing Assets Report",
+        "",
+        f"Scanned {len(md_files)} Markdown files under `{topics_dir}`.",
+        "",
+        "## Summary",
+        "",
+        f"- {len(links)} unresolved cross-page link target(s)",
+        f"- {len(images)} missing image(s)",
+        f"- {len(collisions)} ambiguous image filename(s) (exist in more than one place under images/)",
+        f"- {len(includes)} unresolved `<include>` target(s)",
+        "",
+        render_section("Unresolved cross-page links", links),
+        render_section("Missing images", images),
+        render_section("Unresolved <include> targets", includes),
+        f"## Ambiguous image filenames ({len(collisions)})",
+        "",
+    ]
+    if not collisions:
+        report.append("None.")
+    for name, rels in collisions.items():
+        report.append(f"- `{name}`")
+        report.append(f"  - used: images/{rels[0]}")
+        for rel in rels[1:]:
+            report.append(f"  - ignored: images/{rel}")
+    report.append("")
+
+    args.report_path.write_text("\n".join(report), encoding="utf-8")
+    print(f"Wrote {args.report_path} "
+          f"({len(links)} links, {len(images)} images, {len(collisions)} ambiguous, {len(includes)} includes)")
+
+
+if __name__ == "__main__":
+    main()

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/find_missing_assets.py
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/find_missing_assets.py
@@ -6,7 +6,8 @@ which doesn't actually exist, so broken source content can be found and
 fixed without having to read every generated page.
 
 Usage:
-    python3 find_missing_assets.py <docs-root> [report-path] [--topics-subdir topics] [--images-subdir images]
+    python3 find_missing_assets.py <docs-root> [report-path] [--topics-subdir topics]
+        [--images-subdir images] [--allow-failures]
 
 Reuses md_to_json.py's own link/image resolution (build_topic_index,
 build_image_index, Converter) instead of re-parsing links with regexes, so
@@ -72,6 +73,9 @@ def main():
                          help="Where to write the Markdown report (default: ./missing-assets-report.md)")
     parser.add_argument("--topics-subdir", default="topics", help="Subdirectory of docs_root holding .md files")
     parser.add_argument("--images-subdir", default="images", help="Subdirectory of docs_root holding image files")
+    parser.add_argument("--allow-failures", action="store_true",
+                         help="Exit 0 even if some files failed to scan (default: exit 1 if any did, so this "
+                              "pre-flight gate can't report a clean run over a corpus it couldn't actually read)")
     args = parser.parse_args()
 
     docs_root: Path = args.docs_root
@@ -88,6 +92,7 @@ def main():
     converter = Converter(md, variables, topic_index, image_index)
 
     md_files = sorted(topics_dir.rglob("*.md"))
+    failed = 0
     for md_path in md_files:
         rel = md_path.relative_to(topics_dir)
         page_id = str(rel.with_suffix(""))
@@ -96,6 +101,7 @@ def main():
             converter.convert_file(md_path, page_id, source_rel)
         except Exception as exc:  # noqa: BLE001 - surface which file broke, keep auditing the rest
             print(f"error scanning {md_path}: {exc}", file=sys.stderr)
+            failed += 1
 
     link_warnings = [w for w in converter.warnings if w["kind"] == "link"]
     image_warnings = [w for w in converter.warnings if w["kind"] == "image"]
@@ -117,6 +123,7 @@ def main():
         f"- {len(images)} missing image(s)",
         f"- {len(collisions)} ambiguous image filename(s) (exist in more than one place under images/)",
         f"- {len(includes)} unresolved `<include>` target(s)",
+        f"- {failed} file(s) failed to scan" + (" - **this report is incomplete**" if failed else ""),
         "",
         render_section("Unresolved cross-page links", links),
         render_section("Missing images", images),
@@ -136,6 +143,9 @@ def main():
     args.report_path.write_text("\n".join(report), encoding="utf-8")
     print(f"Wrote {args.report_path} "
           f"({len(links)} links, {len(images)} images, {len(collisions)} ambiguous, {len(includes)} includes)")
+    if failed and not args.allow_failures:
+        print(f"error: {failed} file(s) failed to scan (pass --allow-failures to tolerate this)", file=sys.stderr)
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/insert_optimized_media.py
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/insert_optimized_media.py
@@ -1,0 +1,457 @@
+#!/usr/bin/env python3
+"""
+insert_optimized_media.py
+
+Runs optimize_media.py's image optimizer over a directory of raw media,
+then updates an existing documentation.db-schema database (as
+populate_db.py produces) with the optimized results, fixing up every page
+that referenced a file under its old name.
+
+What this does, inside a single transaction (rolled back on any error):
+  1. Backs up <db_path> first, same as populate_db.py (VACUUM INTO a
+     timestamped sibling file).
+  2. Optimizes every file under <media_dir> into a staging directory
+     (--work-dir, or a temporary one removed afterwards) via
+     optimize_media.py's own pipeline - see its own module docstring for
+     what "optimized" means (resize, pngquant, Scour, optional WEBP
+     conversion / SVG rasterization). Aborts before touching the database
+     if any file fails to optimize.
+  3. Replaces every "k/html/images/<name>" Content row with the optimized
+     bytes, deleting the old row (and any leftover chunked fragments) first
+     - Content.path is UNIQUE, so a stale row has to go before its
+     replacement can be inserted. Images are addressed by bare filename
+     only, matching populate_db.py's own flat "k/html/images/*" convention:
+     <media_dir> subdirectories are flattened to their basename, and a
+     basename collision across two different subdirectories is a warning
+     (keeping the first, sorted, skipping the rest), not an error.
+  4. Wherever optimization renamed a file (webp conversion, or an oversized
+     SVG rasterized to PNG/WEBP), rewrites every "/k/html/images/<old-name>"
+     reference still pointing at the old name, in every k/html/*.html page
+     and the nav row, to the new name - so a page doesn't end up linking to
+     a filename that no longer exists.
+  5. Deletes every remaining "k/html/images/<name>" row (base row and any
+     chunked fragments) that, after the rename rewriting above, no
+     k/html/*.html page or the nav row references even once - not just ones
+     touched by this run's rename_map, but every currently-stored image,
+     so media that fell out of use in an earlier run (e.g. a topic's .md
+     was deleted, or an <img> reference was removed by hand) gets cleaned
+     up too, not just this run's renames.
+  6. VACUUMs the database afterwards (outside the transaction - SQLite
+     refuses to VACUUM inside one), same as populate_db.py.
+
+Usage:
+    python3 insert_optimized_media.py <media_dir> <db_path> [work_dir] [options]
+    python3 insert_optimized_media.py --config myjob.config
+
+<options> are optimize_media.py's own tuning flags (--max-width,
+--jpeg-quality, --webp, --webp-quality, --pngquant-speed, --svg-precision,
+--svg-rasterize-threshold, --verbose, --log-file, --config) - see
+optimize_media.py's own docstring for what each one does. media-dir/db-path/
+work-dir can also be set via --config (as "input-dir"/"db-path"/
+"output-dir"), the same as optimize_media.py's own options.
+
+Note: --webp requires this database's ContentTypes table to already have an
+"image/webp" row (checked up front, before any optimization work starts) -
+this project's documentation.db doesn't ship with one.
+"""
+import argparse
+import re
+import shutil
+import sqlite3
+import sys
+import tempfile
+from pathlib import Path
+
+import brotli
+
+from optimize_media import (
+    BUILTIN_DEFAULTS, Logger, OPTION_SPECS, add_optimize_arguments, find_pngquant, optimize_directory,
+    resolve_config,
+)
+from populate_db import (
+    CHUNK_SIZE, EXTENSION_TO_CONTENT_TYPE, IMAGES_DB_PATH_PREFIX, IMAGES_URL_PREFIX, LANGUAGE, PAGE_CONTENT_TYPE,
+    backup_database, get_content_type, get_id, insert_chunked_content,
+)
+
+WEBP_CONTENT_TYPE = "image/webp"
+# populate_db.py's own EXTENSION_TO_CONTENT_TYPE has no ".webp" entry - its
+# image source (a Writerside export) never produces one, but
+# optimize_media.py's --webp does, so it's added here rather than touching
+# that shared dict.
+IMAGE_EXTENSION_TO_CONTENT_TYPE = {**EXTENSION_TO_CONTENT_TYPE, ".webp": WEBP_CONTENT_TYPE}
+
+# This script's own options, layered on top of optimize_media.py's (db-path
+# has no equivalent there) - passed to resolve_config/load_config_file so
+# --config can set any of them, the same mechanism optimize_media.py uses
+# for its own options.
+OWN_OPTION_SPECS = {**OPTION_SPECS, "db-path": ("db_path", Path)}
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("input_dir", type=Path, nargs="?", default=None, metavar="media_dir",
+                         help="Directory of raw media to optimize, recursively (or set input-dir in --config)")
+    parser.add_argument("db_path", type=Path, nargs="?", default=None,
+                         help="SQLite database to update, e.g. documentation.db (or set db-path in --config)")
+    parser.add_argument("output_dir", type=Path, nargs="?", default=None, metavar="work_dir",
+                         help="Staging directory for optimized files; default: a temporary directory removed "
+                              "afterwards (or set output-dir in --config)")
+    add_optimize_arguments(parser)
+    return parser
+
+
+def delete_content(conn, path: str) -> None:
+    """Deletes a Content row and any chunked continuation fragments for it
+    (see insert_chunked_content/CHUNK_SIZE) - safe to call even if nothing
+    exists yet at that path. Content.path is UNIQUE, so this has to run
+    before any re-insert at the same path."""
+    conn.execute("DELETE FROM Content WHERE path = ? OR path LIKE ?", (path, f"{path}-%"))
+
+
+def insert_optimized_file(conn, data: bytes, name: str, db_path: str, language_id: int, content_type_cache: dict,
+                           chunked_log: list) -> bool:
+    """Inserts one already-optimized file's bytes as-is. Unlike
+    populate_db.py's own insert_file, this does not run pngquant itself -
+    optimize_media.py already did, and running it again here would just
+    re-quantize an already-quantized image for no benefit. Returns False
+    (skipping the file, with a warning) for an extension with no known
+    content type."""
+    content_type_value = IMAGE_EXTENSION_TO_CONTENT_TYPE.get(Path(name).suffix.lower())
+    if content_type_value is None:
+        print(f"warning: no known content type for {name!r}; skipping", file=sys.stderr)
+        return False
+    if content_type_value not in content_type_cache:
+        content_type_cache[content_type_value] = get_content_type(conn, content_type_value)
+    content_type_id, compress = content_type_cache[content_type_value]
+
+    if compress:
+        data = brotli.compress(data)
+    delete_content(conn, db_path)
+    insert_chunked_content(conn, db_path, language_id, content_type_id, 0, data, chunked_log)
+    return True
+
+
+def build_rename_map(manifest: dict, logger: Logger) -> dict:
+    """Flattens optimize_directory's {relative_src: relative_dst} manifest
+    to {old_basename: new_basename}, matching k/html/images/*'s bare-filename
+    addressing. Warns (keeping the first) if two different renames collide
+    on the same old basename - e.g. two identically-named files in
+    different subdirectories of media_dir."""
+    rename_map = {}
+    for old_rel, new_rel in sorted(manifest.items()):
+        old_name = Path(old_rel).name
+        new_name = Path(new_rel).name
+        if old_name == new_name:
+            continue
+        if old_name in rename_map and rename_map[old_name] != new_name:
+            logger.error(
+                f"warning: {old_rel!r} and an earlier file both renamed from {old_name!r}, to different names "
+                f"({rename_map[old_name]!r} vs {new_name!r}); keeping the first"
+            )
+            continue
+        rename_map[old_name] = new_name
+    return rename_map
+
+
+def reassemble_content(conn, path: str, first_content: bytes) -> bytes:
+    """Reassembles a possibly-chunked row's full bytes - mirrors
+    WebServer.kt's own reassembly protocol (see CHUNK_SIZE's docstring in
+    populate_db.py): a row is fragmented purely when its content is exactly
+    CHUNK_SIZE bytes, in which case "<path>-1", "<path>-2", ... are
+    concatenated until a missing or shorter-than-CHUNK_SIZE row is hit."""
+    if len(first_content) < CHUNK_SIZE:
+        return first_content
+    parts = [first_content]
+    n = 1
+    while True:
+        row = conn.execute("SELECT content FROM Content WHERE path = ?", (f"{path}-{n}",)).fetchone()
+        if row is None:
+            break
+        parts.append(row[0])
+        if len(row[0]) < CHUNK_SIZE:
+            break
+        n += 1
+    return b"".join(parts)
+
+
+def rewrite_pages(conn, rename_map: dict, language_id: int, page_content_type_id: int, logger: Logger,
+                   chunked_log: list) -> int:
+    """Rewrites every k/html/*.html page (and the nav row) that references a
+    renamed image, replacing "/k/html/images/<old-name>" with
+    "/k/html/images/<new-name>" wherever it appears. Operates directly on
+    each row's decompressed JSON text rather than parsing it: every image
+    reference is a literal IMAGES_URL_PREFIX+filename substring, baked in at
+    conversion time by md_to_json.py's Converter (resolve_image_src), so a
+    plain text substitution finds it correctly regardless of which block
+    type it ends up nested inside - no need to understand that nested block
+    schema here. The match is anchored on the escaped quote (\\") that
+    always immediately follows a rewritten src="..." attribute in the
+    stored JSON (see resolve_image_src/rewrite_urls - image references are
+    only ever embedded as HTML attributes, never as a bare JSON field on
+    their own), so a renamed file's name can't accidentally match as a
+    prefix of some other, unrelated, longer filename. Returns the number of
+    rows changed.
+
+    ".html" is the exact literal suffix populate_db.py gives every base
+    page/nav row; fragment continuation rows are named "<path>-<N>" (the
+    "-N" appended after the ".html" already in path), so the path filter
+    below naturally excludes them without needing to detect chunking up
+    front.
+
+    Substitutes in a single pass over each row's original text (one regex
+    covering every old_name, dispatched through `replacements` by exact
+    match) rather than N sequential str.replace calls on a mutating buffer.
+    Sequential replaces would risk a chain rename: if one rename's new_name
+    equals another rename's old_name (e.g. foo.png -> foo.webp and,
+    unrelated, foo.webp -> foo-2.webp), a later replace could re-match text
+    an earlier replace just wrote, sending an original foo.png reference to
+    foo-2.webp instead of foo.webp. Scanning the untouched original text
+    once makes that impossible."""
+    if not rename_map:
+        return 0
+
+    rows = conn.execute(
+        "SELECT path, content, templateId FROM Content WHERE path LIKE 'k/html/%.html' AND contentTypeID = ? "
+        "AND templateId != 0",
+        (page_content_type_id,),
+    ).fetchall()
+
+    replacements = {
+        f'{IMAGES_URL_PREFIX}{old_name}\\"': f'{IMAGES_URL_PREFIX}{new_name}\\"'
+        for old_name, new_name in rename_map.items()
+    }
+    old_ref_pattern = re.compile("|".join(re.escape(old_ref) for old_ref in replacements))
+
+    changed = 0
+    for path, first_content, template_id in rows:
+        full = reassemble_content(conn, path, first_content)
+        text = brotli.decompress(full).decode("utf-8")
+        hits = len(old_ref_pattern.findall(text))
+        if not hits:
+            continue
+        new_text = old_ref_pattern.sub(lambda m: replacements[m.group(0)], text)
+        blob = brotli.compress(new_text.encode("utf-8"))
+        delete_content(conn, path)
+        insert_chunked_content(conn, path, language_id, page_content_type_id, template_id, blob, chunked_log)
+        changed += 1
+        logger.info(f"[URL FIX] {path}: updated {hits} image reference(s)")
+    return changed
+
+
+# Matches a rewritten image src's filename, anchored the same way
+# rewrite_pages' own known-rename substitutions are: resolve_image_src/
+# rewrite_urls only ever embed an image reference as an HTML src="..."
+# attribute, which - JSON-encoded - always has the escaped quote (\") right
+# after it, so this can't accidentally swallow past the end of the filename.
+IMAGE_REF_RE = re.compile(re.escape(IMAGES_URL_PREFIX) + r'([^\\"]+)\\"')
+
+
+def collect_referenced_media(conn, page_content_type_id: int) -> set:
+    """Bare filenames (e.g. "mascot.png") referenced by at least one
+    src="/k/html/images/<name>" anywhere across current k/html/*.html page
+    content and the nav row - the same row selection/reassembly
+    rewrite_pages uses, just extracting every image reference found instead
+    of only substituting the ones in a known rename_map."""
+    rows = conn.execute(
+        "SELECT path, content FROM Content WHERE path LIKE 'k/html/%.html' AND contentTypeID = ? AND templateId != 0",
+        (page_content_type_id,),
+    ).fetchall()
+    referenced = set()
+    for path, first_content in rows:
+        full = reassemble_content(conn, path, first_content)
+        text = brotli.decompress(full).decode("utf-8")
+        referenced.update(IMAGE_REF_RE.findall(text))
+    return referenced
+
+
+def list_stored_media(conn) -> dict:
+    """Bare filename -> Content.path (e.g. "mascot.png" -> "k/html/images/
+    mascot.png") for every image currently stored under IMAGES_DB_PATH_PREFIX,
+    collapsing chunked continuation fragments ("<path>-1", "<path>-2", ...)
+    back into their base row, since deleting the base via delete_content
+    already takes its fragments with it (see CHUNK_SIZE's docstring in
+    populate_db.py for that fragmentation convention). A path is treated as
+    a fragment when stripping a trailing "-<digits>" yields another path
+    that's also present - the same convention this whole pipeline already
+    relies on elsewhere, ambiguous only for a base filename that itself
+    looks like "<other-existing-file>-<digits>", which no real optimized
+    media filename does."""
+    paths = {row[0] for row in conn.execute(
+        "SELECT path FROM Content WHERE path LIKE ?", (f"{IMAGES_DB_PATH_PREFIX}%",)
+    )}
+
+    def is_fragment(path: str) -> bool:
+        prefix, sep, suffix = path.rpartition("-")
+        return sep == "-" and suffix.isdigit() and prefix in paths
+
+    return {path[len(IMAGES_DB_PATH_PREFIX):]: path for path in paths if not is_fragment(path)}
+
+
+def delete_unreferenced_media(conn, page_content_type_id: int, logger: Logger) -> int:
+    """Deletes every currently-stored k/html/images/<name> row (base row and
+    any chunked fragments) that no page or the nav row references even once.
+    Must run after insertion and rename-rewriting, so it sees the final,
+    up-to-date state of both stored media and in-content references - a file
+    renamed this run is only "unreferenced" under its stale old name, which
+    rewrite_pages will have already fixed up by the time this runs. Returns
+    the number of images removed."""
+    stored = list_stored_media(conn)
+    referenced = collect_referenced_media(conn, page_content_type_id)
+    removed = 0
+    for name, path in sorted(stored.items()):
+        if name in referenced:
+            continue
+        delete_content(conn, path)
+        removed += 1
+        logger.info(f"[UNUSED] removed {path} (not referenced by any page)")
+    return removed
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    try:
+        cfg = resolve_config(args, OWN_OPTION_SPECS, BUILTIN_DEFAULTS)
+    except RuntimeError as exc:
+        parser.error(str(exc))
+        return
+
+    if cfg["input_dir"] is None or cfg["db_path"] is None:
+        parser.error("media_dir and db_path must be given either as positional arguments or in --config")
+
+    log_file_handle = open(cfg["log_file"], "w", encoding="utf-8") if cfg["log_file"] else None
+    logger = Logger(log_file_handle)
+    work_dir_is_temp = cfg["output_dir"] is None
+    work_dir = cfg["output_dir"] or Path(tempfile.mkdtemp(prefix="insert_optimized_media_"))
+
+    try:
+        if not cfg["input_dir"].is_dir():
+            logger.error(f"error: {cfg['input_dir']} is not a directory")
+            sys.exit(1)
+        if not cfg["db_path"].is_file():
+            logger.error(f"error: {cfg['db_path']} does not exist")
+            sys.exit(1)
+
+        if cfg["verbose"]:
+            logger.info("Config parameters:")
+            for key, (dest, _converter) in OWN_OPTION_SPECS.items():
+                logger.info(f"  {key} = {cfg.get(dest)}")
+            logger.info(f"  work-dir = {work_dir}{' (temporary)' if work_dir_is_temp else ''}")
+            if args.config:
+                logger.info(f"  (loaded from {args.config})")
+
+        try:
+            pngquant_path = find_pngquant()
+        except RuntimeError as exc:
+            logger.error(f"error: {exc}")
+            sys.exit(1)
+
+        # Fail fast on a schema this database doesn't support - before
+        # spending time optimizing every file - rather than discovering it
+        # partway through the (rolled-back, but still wasted) DB transaction.
+        preflight_conn = sqlite3.connect(cfg["db_path"])
+        try:
+            get_id(preflight_conn, "Languages", LANGUAGE)
+            get_id(preflight_conn, "ContentTypes", PAGE_CONTENT_TYPE)
+            if cfg["webp"]:
+                get_content_type(preflight_conn, WEBP_CONTENT_TYPE)
+        except RuntimeError as exc:
+            logger.error(f"error: {exc}")
+            sys.exit(1)
+        finally:
+            preflight_conn.close()
+
+        work_dir.mkdir(parents=True, exist_ok=True)
+        stats = {"raster": 0, "svg": 0, "svg_rasterized": 0, "copied": 0, "errors": 0, "original_bytes": 0,
+                  "optimized_bytes": 0}
+        logger.info(f"Optimizing media from {cfg['input_dir']} into {work_dir}...")
+        manifest = optimize_directory(cfg["input_dir"], work_dir, cfg=cfg, pngquant_path=pngquant_path,
+                                       logger=logger, stats=stats)
+        if stats["errors"]:
+            logger.error(
+                f"error: {stats['errors']} file(s) failed to optimize; aborting before touching the database"
+            )
+            sys.exit(1)
+        rename_map = build_rename_map(manifest, logger)
+
+        logger.info(f"Backing up {cfg['db_path']}...")
+        backup_path = backup_database(cfg["db_path"])
+        logger.info(f"Backup written to {backup_path}")
+
+        conn = sqlite3.connect(cfg["db_path"])
+        try:
+            conn.execute("BEGIN")
+            language_id = get_id(conn, "Languages", LANGUAGE)
+            page_content_type_id = get_id(conn, "ContentTypes", PAGE_CONTENT_TYPE)
+
+            content_type_cache = {}
+            chunked_log = []
+            inserted = 0
+            seen_names = {}
+            for out_path in sorted(work_dir.rglob("*")):
+                if out_path.is_dir():
+                    continue
+                name = out_path.name
+                if name in seen_names:
+                    logger.error(
+                        f"warning: {out_path} has the same filename as {seen_names[name]}; keeping the first, "
+                        "skipping this one"
+                    )
+                    continue
+                seen_names[name] = out_path
+                db_path = f"{IMAGES_DB_PATH_PREFIX}{name}"
+                if insert_optimized_file(conn, out_path.read_bytes(), name, db_path, language_id, content_type_cache,
+                                          chunked_log):
+                    inserted += 1
+                    if cfg["verbose"]:
+                        logger.info(f"[OK] {out_path} -> {db_path}")
+
+            # A renamed file's old basename no longer appears anywhere under
+            # work_dir (that's what makes it a rename), so the loop above
+            # never visits its old db_path to replace it - it'd otherwise
+            # linger forever as an orphaned, no-longer-referenced row.
+            removed = 0
+            for old_name in rename_map:
+                old_db_path = f"{IMAGES_DB_PATH_PREFIX}{old_name}"
+                delete_content(conn, old_db_path)
+                removed += 1
+                if cfg["verbose"]:
+                    logger.info(f"[REMOVED] {old_db_path} (renamed to {IMAGES_DB_PATH_PREFIX}{rename_map[old_name]})")
+
+            changed_pages = rewrite_pages(conn, rename_map, language_id, page_content_type_id, logger, chunked_log)
+
+            unreferenced_removed = delete_unreferenced_media(conn, page_content_type_id, logger)
+
+            conn.commit()
+        except Exception:
+            conn.rollback()
+            raise
+        finally:
+            conn.close()
+
+        logger.info("Vacuuming database to reclaim freed space...")
+        vacuum_conn = sqlite3.connect(cfg["db_path"])
+        try:
+            vacuum_conn.execute("VACUUM")
+        finally:
+            vacuum_conn.close()
+
+        logger.info(
+            f"Done: inserted/updated {inserted} image(s) in {cfg['db_path']}, {removed} stale renamed-away row(s) "
+            f"removed, {changed_pages} page(s)/nav row(s) updated to match {len(rename_map)} renamed file(s), "
+            f"{unreferenced_removed} unreferenced image(s) deleted."
+        )
+        if chunked_log:
+            logger.info(f"Chunked {len(chunked_log)} file(s) over {CHUNK_SIZE:,} bytes:")
+            for path, total_size, chunk_count in chunked_log:
+                logger.info(f"  {path}: {total_size:,} bytes -> {chunk_count} chunks")
+    finally:
+        if log_file_handle is not None:
+            log_file_handle.close()
+        if work_dir_is_temp:
+            shutil.rmtree(work_dir, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/optimize_media.py
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/optimize_media.py
@@ -43,9 +43,9 @@ prints all resolved config parameters up front). --log-file redirects all
 log output (those per-file lines, warnings, and errors) to that file
 instead of stdout/stderr.
 
-Requires the "pngquant" binary on PATH, the Pillow and scour Python packages
-(pip install Pillow scour), and - only if any SVG actually needs rasterizing
-- the cairosvg package (pip install cairosvg).
+Requires the "pngquant" binary on PATH, plus the Pillow, scour and cairosvg
+Python packages listed in requirements.txt - run via
+`uv run --with-requirements <repo-root>/requirements.txt optimize_media.py ...`.
 """
 import argparse
 import io
@@ -299,7 +299,8 @@ def rasterize_svg(svg_text: str, max_width: int) -> Image.Image:
         import cairosvg
     except ImportError as exc:
         raise RuntimeError(
-            "cairosvg is required to rasterize oversized SVGs; install it with `pip install cairosvg`"
+            "cairosvg is required to rasterize oversized SVGs; it's in requirements.txt - "
+            "run this script via `uv run --with-requirements <repo-root>/requirements.txt`"
         ) from exc
     png_bytes = cairosvg.svg2png(bytestring=svg_text.encode("utf-8"), output_width=max_width)
     img = Image.open(io.BytesIO(png_bytes))

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/optimize_media.py
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/optimize_media.py
@@ -1,0 +1,570 @@
+#!/usr/bin/env python3
+"""
+optimize_media.py
+
+Recursively mirrors an input directory into an output directory, optimizing
+image files along the way and copying everything else unchanged.
+
+  - Raster images (png, jpg/jpeg, gif, bmp, tif/tiff, webp) are downscaled to
+    a maximum width (default 500px, preserving aspect ratio, never upscaled),
+    then optimized: PNGs through pngquant (at a configurable --pngquant-speed
+    trade-off - see https://pngquant.org/), other formats through Pillow's
+    own encoder (quality/optimize flags). With --webp, the resized image is
+    saved as WEBP instead of its original format. Animated GIFs get every
+    frame resized the same way (preserving frame count/duration/loop count)
+    rather than being copied through unchanged; --webp is not applied to
+    them, since animated WEBP re-encoding isn't implemented here. Any other
+    animated format (e.g. an animated WEBP given as input) is still copied
+    through unchanged, since per-frame resizing isn't implemented for it.
+  - SVGs (.svg) are aggressively optimized with the Scour library: metadata,
+    comments and editor cruft stripped, ids shortened, whitespace collapsed,
+    and every number rounded to --svg-precision decimal places. If the
+    optimized SVG still exceeds --svg-rasterize-threshold bytes, it's
+    rasterized (via cairosvg) and run through the same raster pipeline above
+    instead of being kept as a vector. If rasterizing fails for any reason
+    (e.g. cairosvg isn't installed), that's logged as a warning and the
+    optimized (still oversized) SVG is written instead - every input file
+    always ends up with something at its mirrored output path.
+  - Every other file is copied through unchanged.
+
+Usage:
+    python3 optimize_media.py <input_dir> <output_dir> [options]
+    python3 optimize_media.py --config myjob.config
+
+All options may instead be set in a .config file (one `key = value` per
+line, '#' for comments) passed via --config; see OPTION_SPECS below for the
+recognized keys, which are the same as the long-form CLI flags. Values
+explicitly given on the command line always take precedence over the config
+file.
+
+Every media file processed logs a line with its original and optimized
+locations, regardless of --verbose (which adds byte sizes to that line and
+prints all resolved config parameters up front). --log-file redirects all
+log output (those per-file lines, warnings, and errors) to that file
+instead of stdout/stderr.
+
+Requires the "pngquant" binary on PATH, the Pillow and scour Python packages
+(pip install Pillow scour), and - only if any SVG actually needs rasterizing
+- the cairosvg package (pip install cairosvg).
+"""
+import argparse
+import io
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+try:
+    RESAMPLE = Image.Resampling.LANCZOS
+except AttributeError:  # Pillow < 9.1
+    RESAMPLE = Image.LANCZOS
+
+RASTER_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".bmp", ".tif", ".tiff", ".webp"}
+SVG_EXTENSION = ".svg"
+
+
+class Logger:
+    """Routes both info-level and error-level messages to a single
+    destination: the --log-file path if one was given (so a redirected run
+    still has one coherent, chronological log to inspect afterwards), or
+    stdout/stderr otherwise (so a normal terminal run keeps its usual
+    split - errors are still visible even if stdout is piped elsewhere)."""
+
+    def __init__(self, file_handle):
+        self._fh = file_handle
+
+    def info(self, msg: str) -> None:
+        print(msg, file=self._fh if self._fh is not None else sys.stdout, flush=self._fh is not None)
+
+    def error(self, msg: str) -> None:
+        print(msg, file=self._fh if self._fh is not None else sys.stderr, flush=self._fh is not None)
+
+
+def parse_bool(value: str) -> bool:
+    v = value.strip().lower()
+    if v in ("1", "true", "yes", "on", "y", "t"):
+        return True
+    if v in ("0", "false", "no", "off", "n", "f"):
+        return False
+    raise ValueError(f"not a boolean: {value!r}")
+
+
+# Maps a config-file key (and, with dashes, a --long-form CLI flag) to the
+# argparse dest it corresponds to and the converter used to parse its value
+# out of the config file's plain-text "key = value" form. Order here is also
+# the order config parameters get listed in when --verbose is on.
+OPTION_SPECS = {
+    "input-dir": ("input_dir", Path),
+    "output-dir": ("output_dir", Path),
+    "max-width": ("max_width", int),
+    "jpeg-quality": ("jpeg_quality", int),
+    "webp": ("webp", parse_bool),
+    "webp-quality": ("webp_quality", int),
+    "pngquant-speed": ("pngquant_speed", int),
+    "svg-precision": ("svg_precision", int),
+    "svg-rasterize-threshold": ("svg_rasterize_threshold", int),
+    "verbose": ("verbose", parse_bool),
+    "log-file": ("log_file", Path),
+}
+
+# Used for any option left unset by both the CLI and (if given) --config.
+BUILTIN_DEFAULTS = {
+    "max_width": 500,
+    "jpeg_quality": 82,
+    "webp": False,
+    "webp_quality": 80,
+    "pngquant_speed": 4,  # pngquant's own default; 1 = slow/best, 11 = fast/rough
+    "svg_precision": 4,
+    "svg_rasterize_threshold": 300 * 1024,  # 300KB
+    "verbose": False,
+}
+
+
+def load_config_file(path: Path, option_specs: dict = OPTION_SPECS) -> dict:
+    """Parses a simple `key = value` (or `key: value`) config file, one
+    option per line; blank lines and lines starting with '#' or ';' are
+    ignored. A bare key with no value means true (for boolean options).
+    Keys match `option_specs` (case-insensitive, dashes or underscores) -
+    defaulting to this module's own OPTION_SPECS, but overridable so a
+    caller layering its own options on top (e.g. insert_optimized_media.py
+    adding "db-path") can reuse this same parser for its extended key set.
+    Returns {dest: converted_value}."""
+    if not path.is_file():
+        raise RuntimeError(f"config file not found: {path}")
+
+    overrides = {}
+    for lineno, raw_line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        line = raw_line.strip()
+        if not line or line.startswith("#") or line.startswith(";"):
+            continue
+        if "=" in line:
+            key, _, value = line.partition("=")
+        elif ":" in line:
+            key, _, value = line.partition(":")
+        else:
+            key, value = line, "true"
+        key = key.strip().lower().replace("_", "-")
+        value = value.strip()
+
+        spec = option_specs.get(key)
+        if spec is None:
+            raise RuntimeError(f"{path}:{lineno}: unknown config option {key!r}")
+        dest, converter = spec
+        try:
+            overrides[dest] = converter(value)
+        except ValueError as exc:
+            raise RuntimeError(f"{path}:{lineno}: invalid value for {key!r}: {exc}") from exc
+    return overrides
+
+
+def find_pngquant() -> str:
+    path = shutil.which("pngquant")
+    if path is None:
+        raise RuntimeError("pngquant not found on PATH; install it (e.g. `apt install pngquant`) and retry")
+    return path
+
+
+def quantize_png_bytes(data: bytes, pngquant_path: str, speed: int, name: str, logger: Logger) -> bytes:
+    """Runs pngquant on raw PNG bytes (stdin -> stdout, no temp files) at the
+    given --speed trade-off (1 = slow/best quality, 11 = fast/rough - see
+    https://pngquant.org/), returning the compressed bytes. Falls back to
+    the original bytes if pngquant declines (e.g. exit 99: result would fall
+    below --quality's floor) or otherwise fails - a slightly larger PNG
+    beats a missing one."""
+    result = subprocess.run(
+        [pngquant_path, "--quality", "65-95", "--speed", str(speed), "--strip", "--force", "--output", "-", "-"],
+        input=data, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False,
+    )
+    if result.returncode != 0 or not result.stdout:
+        logger.error(
+            f"warning: pngquant declined to compress {name!r} "
+            f"(exit {result.returncode}: {result.stderr.decode(errors='replace').strip()}); keeping original"
+        )
+        return data
+    return result.stdout
+
+
+def resize_if_needed(img: Image.Image, max_width: int) -> Image.Image:
+    if img.width <= max_width:
+        return img
+    new_height = max(1, round(img.height * (max_width / img.width)))
+    return img.resize((max_width, new_height), RESAMPLE)
+
+
+def normalize_mode(img: Image.Image) -> Image.Image:
+    """Flattens palette/CMYK modes to something every downstream encoder
+    (JPEG, WEBP, PNG) can handle directly, preserving alpha where present."""
+    if img.mode == "P":
+        return img.convert("RGBA") if img.info.get("transparency") is not None else img.convert("RGB")
+    if img.mode == "CMYK":
+        return img.convert("RGB")
+    return img
+
+
+def encode_raster(img: Image.Image, dst: Path, *, suffix: str, max_width: int, jpeg_quality: int, webp: bool,
+                   webp_quality: int, pngquant_path: str, pngquant_speed: int, logger: Logger) -> Path:
+    """Resizes an already-loaded image and writes it under dst (whose suffix
+    may be swapped to .webp), choosing the encoder by `suffix` (the source
+    file's extension, or ".png" for a freshly rasterized SVG). Returns the
+    path actually written. Shared by optimize_raster and optimize_svg's
+    rasterize-on-oversize fallback so both go through identical resize/
+    encode logic."""
+    img = normalize_mode(img)
+
+    if suffix == ".png" and not webp:
+        # pngquant runs against the full-resolution pixels here, before any
+        # downscaling - its palette selection and dithering have the whole
+        # original image's color detail to work from, rather than the
+        # coarser, already-blended pixels a resize would leave it with. The
+        # quantized result is then decoded back and resized down below, same
+        # as any other image.
+        buf = io.BytesIO()
+        img.save(buf, "PNG", optimize=True)
+        quantized = quantize_png_bytes(buf.getvalue(), pngquant_path, pngquant_speed, str(dst), logger)
+        img = Image.open(io.BytesIO(quantized))
+        img.load()
+        img = normalize_mode(img)  # pngquant's output PNG is palette ("P") mode
+
+    img = resize_if_needed(img, max_width)
+
+    if webp:
+        dst = dst.with_suffix(".webp")
+        img.save(dst, "WEBP", quality=webp_quality, method=6)
+        return dst
+
+    if suffix == ".png":
+        # Resizing the first quantize pass's palette image back down blended
+        # it back into full RGB(A) - re-quantize at the final size to
+        # restore a compact palette PNG, now informed by both the full-
+        # resolution pass above and the actual delivered dimensions.
+        buf = io.BytesIO()
+        img.save(buf, "PNG", optimize=True)
+        dst.write_bytes(quantize_png_bytes(buf.getvalue(), pngquant_path, pngquant_speed, str(dst), logger))
+    elif suffix in (".jpg", ".jpeg"):
+        if img.mode != "RGB":
+            img = img.convert("RGB")
+        img.save(dst, "JPEG", quality=jpeg_quality, optimize=True, progressive=True)
+    else:
+        img.save(dst, optimize=True)
+    return dst
+
+
+def resize_animated_gif(img: Image.Image, dst: Path, max_width: int) -> Path:
+    """Resizes every frame of an animated GIF down to max_width, preserving
+    frame count, each frame's own duration, and the loop count - a naive
+    single-frame resize (or the old copy-through-unchanged behavior) would
+    otherwise silently drop the animation entirely. seek()+convert("RGBA")
+    composites each frame the way Pillow's GIF plugin normally displays it
+    (accounting for the previous frame's disposal method), so every frame
+    saved below is a complete, standalone image rather than a partial
+    update relying on its predecessor - hence disposal=2 (restore to
+    background) on save, rather than trying to preserve each original
+    frame's own disposal method. --webp is intentionally not honored here:
+    animated WEBP re-encoding is a separate feature this doesn't attempt."""
+    n_frames = getattr(img, "n_frames", 1)
+    loop = img.info.get("loop", 0)
+    frames = []
+    durations = []
+    for i in range(n_frames):
+        img.seek(i)
+        frames.append(resize_if_needed(img.convert("RGBA"), max_width))
+        durations.append(img.info.get("duration", 100))
+    frames[0].save(
+        dst, save_all=True, append_images=frames[1:], duration=durations, loop=loop, disposal=2, optimize=True,
+    )
+    return dst
+
+
+def optimize_raster(src: Path, dst: Path, **encode_kwargs) -> Path:
+    with Image.open(src) as img:
+        if getattr(img, "is_animated", False):
+            if src.suffix.lower() == ".gif":
+                return resize_animated_gif(img, dst, encode_kwargs["max_width"])
+            # Animated non-GIF (e.g. webp): per-frame resizing/re-encoding is
+            # out of scope here - copy through unchanged rather than
+            # flattening it to a single frame and silently breaking the
+            # animation.
+            shutil.copy2(src, dst)
+            return dst
+        return encode_raster(img, dst, suffix=src.suffix.lower(), **encode_kwargs)
+
+
+def rasterize_svg(svg_text: str, max_width: int) -> Image.Image:
+    """Renders SVG markup to a raster image at exactly `max_width` pixels
+    wide (cairosvg computes the proportional height from the SVG's own
+    viewBox/aspect ratio), for SVGs too large to keep as vector output."""
+    try:
+        import cairosvg
+    except ImportError as exc:
+        raise RuntimeError(
+            "cairosvg is required to rasterize oversized SVGs; install it with `pip install cairosvg`"
+        ) from exc
+    png_bytes = cairosvg.svg2png(bytestring=svg_text.encode("utf-8"), output_width=max_width)
+    img = Image.open(io.BytesIO(png_bytes))
+    img.load()
+    return img
+
+
+def optimize_svg(src: Path, dst: Path, *, precision: int, rasterize_threshold: int, max_width: int,
+                  jpeg_quality: int, webp: bool, webp_quality: int, pngquant_path: str, pngquant_speed: int,
+                  logger: Logger) -> tuple:
+    """Optimizes one SVG with Scour, rounding numbers to `precision` decimal
+    places. If the optimized markup is still over `rasterize_threshold`
+    bytes, rasterizes it and runs it through the raster pipeline instead of
+    writing it as a (still large) vector. Returns (final_path, was_rasterized)."""
+    from scour import scour
+
+    options = scour.generateDefaultOptions()
+    # Aggressive settings, roughly equivalent to:
+    #   scour --enable-viewboxing --enable-id-stripping --enable-comment-stripping
+    #         --shorten-ids --indent=none --strip-xml-prolog --set-precision=<precision>
+    options.remove_metadata = True
+    options.remove_descriptive_elements = True
+    options.remove_titles = True
+    options.remove_descriptions = True
+    options.strip_comments = True
+    options.strip_ids = True
+    options.shorten_ids = True
+    options.keep_editor_data = False
+    options.strip_xml_prolog = True
+    options.enable_viewboxing = True
+    options.simple_colors = True
+    options.style_to_xml = True
+    options.group_collapse = True
+    options.group_create = True
+    options.indent_type = "none"
+    options.newlines = False
+    options.digits = precision
+
+    in_string = src.read_text(encoding="utf-8")
+    out_string = scour.scourString(in_string, options)
+    out_bytes = out_string.encode("utf-8")
+
+    if len(out_bytes) > rasterize_threshold:
+        try:
+            img = rasterize_svg(out_string, max_width)
+            final = encode_raster(
+                img, dst.with_suffix(".png"), suffix=".png", max_width=max_width, jpeg_quality=jpeg_quality,
+                webp=webp, webp_quality=webp_quality, pngquant_path=pngquant_path, pngquant_speed=pngquant_speed,
+                logger=logger,
+            )
+            logger.info(
+                f"note: rasterized {src} -> {final} (optimized SVG was {len(out_bytes):,} bytes, "
+                f"over the {rasterize_threshold:,} byte threshold)"
+            )
+            return final, True
+        except Exception as exc:  # noqa: BLE001 - fall through to writing the vector below instead
+            logger.error(f"warning: failed to rasterize {src} ({exc}); keeping optimized SVG instead")
+
+    dst.write_bytes(out_bytes)
+    return dst, False
+
+
+def process_file(src: Path, dst: Path, *, cfg: dict, pngquant_path: str, stats: dict, logger: Logger) -> Path:
+    """Optimizes (or copies through) one file. Returns the path actually
+    written on success (which may differ from `dst` - webp conversion or
+    SVG rasterization changes the extension), or None on error (already
+    logged; `stats["errors"]` is incremented so callers can tell without
+    inspecting the return value)."""
+    dst.parent.mkdir(parents=True, exist_ok=True)
+    suffix = src.suffix.lower()
+    original_size = src.stat().st_size
+
+    try:
+        if suffix == SVG_EXTENSION:
+            dst_final, rasterized = optimize_svg(
+                src, dst, precision=cfg["svg_precision"], rasterize_threshold=cfg["svg_rasterize_threshold"],
+                max_width=cfg["max_width"], jpeg_quality=cfg["jpeg_quality"], webp=cfg["webp"],
+                webp_quality=cfg["webp_quality"], pngquant_path=pngquant_path, pngquant_speed=cfg["pngquant_speed"],
+                logger=logger,
+            )
+            if rasterized:
+                stats["svg_rasterized"] += 1
+                kind = "svg, rasterized"
+            else:
+                stats["svg"] += 1
+                kind = "svg"
+        elif suffix in RASTER_EXTENSIONS:
+            dst_final = optimize_raster(
+                src, dst, max_width=cfg["max_width"], jpeg_quality=cfg["jpeg_quality"], webp=cfg["webp"],
+                webp_quality=cfg["webp_quality"], pngquant_path=pngquant_path, pngquant_speed=cfg["pngquant_speed"],
+                logger=logger,
+            )
+            stats["raster"] += 1
+            kind = "raster"
+        else:
+            shutil.copy2(src, dst)
+            dst_final = dst
+            stats["copied"] += 1
+            kind = "copied"
+    except Exception as exc:  # noqa: BLE001 - keep processing the rest of the tree
+        stats["errors"] += 1
+        logger.error(f"error: failed to process {src}: {exc}")
+        return None
+
+    optimized_size = dst_final.stat().st_size
+    stats["original_bytes"] += original_size
+    stats["optimized_bytes"] += optimized_size
+    if kind != "copied":
+        # Always shown (not just under --verbose) - a per-file record of
+        # where the optimized copy of each media file actually landed,
+        # since that's not otherwise derivable once optimization has
+        # renamed a file (webp conversion, SVG rasterization).
+        message = f"Optimized {src} -> {dst_final}"
+        if cfg["verbose"]:
+            saved = original_size - optimized_size
+            pct = (saved / original_size * 100) if original_size else 0.0
+            message = (
+                f"[OK][{kind}] {src} -> {dst_final}: {original_size:,} -> {optimized_size:,} bytes "
+                f"(saved {saved:,} bytes, {pct:.1f}%)"
+            )
+        logger.info(message)
+    return dst_final
+
+
+def optimize_directory(input_dir: Path, output_dir: Path, *, cfg: dict, pngquant_path: str, logger: Logger,
+                        stats: dict) -> dict:
+    """Walks input_dir recursively, optimizing every file into the mirrored
+    location under output_dir (see process_file). Returns
+    {relative_src_path: relative_dst_path} for every file whose output path
+    ended up different from its input path (webp conversion, or an SVG
+    rasterized to PNG/WEBP) - callers that also maintain references to these
+    files elsewhere (e.g. insert_optimized_media.py, fixing up image URLs
+    stored in a database) use this to know what changed."""
+    renamed = {}
+    for src in sorted(input_dir.rglob("*")):
+        if src.is_dir():
+            continue
+        rel = src.relative_to(input_dir)
+        dst = output_dir / rel
+        dst_final = process_file(src, dst, cfg=cfg, pngquant_path=pngquant_path, stats=stats, logger=logger)
+        if dst_final is None:
+            continue
+        rel_final = dst_final.relative_to(output_dir)
+        if rel_final != rel:
+            renamed[str(rel)] = str(rel_final)
+    return renamed
+
+
+def add_optimize_arguments(parser: argparse.ArgumentParser) -> None:
+    """Adds every --tuning-flag (everything except the input/output
+    positionals) to `parser` - split out from build_parser() so a caller
+    with its own positional arguments (e.g. insert_optimized_media.py, which
+    also needs a database path) can still get these for free instead of
+    redeclaring them."""
+    parser.add_argument("--config", type=Path, default=None,
+                         help="Path to a .config file providing any of the options below")
+    parser.add_argument("--max-width", type=int, default=None,
+                         help=f"Max width in pixels for raster images (default: {BUILTIN_DEFAULTS['max_width']})")
+    parser.add_argument("--jpeg-quality", type=int, default=None,
+                         help=f"JPEG output quality, 0-95 (default: {BUILTIN_DEFAULTS['jpeg_quality']})")
+    parser.add_argument("--webp", action="store_true", default=None,
+                         help="Convert optimized raster images (and rasterized SVGs) to WEBP")
+    parser.add_argument("--webp-quality", type=int, default=None,
+                         help=f"WEBP output quality, 0-100 (default: {BUILTIN_DEFAULTS['webp_quality']})")
+    parser.add_argument("--pngquant-speed", type=int, default=None,
+                         help="pngquant speed/quality trade-off, 1 (slow/best) - 11 (fast/rough); "
+                              f"see https://pngquant.org/ (default: {BUILTIN_DEFAULTS['pngquant_speed']})")
+    parser.add_argument("--svg-precision", type=int, default=None,
+                         help="Decimal places to round SVG numbers to via Scour "
+                              f"(default: {BUILTIN_DEFAULTS['svg_precision']})")
+    parser.add_argument("--svg-rasterize-threshold", type=int, default=None,
+                         help="Rasterize an optimized SVG if it's still over this many bytes "
+                              f"(default: {BUILTIN_DEFAULTS['svg_rasterize_threshold']:,})")
+    parser.add_argument("--verbose", action="store_true", default=None,
+                         help="Add original/optimized byte sizes to the per-file log line every media file "
+                              "already gets, plus all resolved config parameters up front")
+    parser.add_argument("--log-file", type=Path, default=None,
+                         help="Write all log output here instead of stdout/stderr")
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("input_dir", type=Path, nargs="?", default=None,
+                         help="Directory to read files from, recursively (or set input-dir in --config)")
+    parser.add_argument("output_dir", type=Path, nargs="?", default=None,
+                         help="Directory to mirror optimized output into (or set output-dir in --config)")
+    add_optimize_arguments(parser)
+    return parser
+
+
+def resolve_config(args: argparse.Namespace, option_specs: dict = OPTION_SPECS,
+                    builtin_defaults: dict = BUILTIN_DEFAULTS) -> dict:
+    """Merges CLI args over --config file values over builtin_defaults (in
+    that precedence order) into one dict keyed by dest name. option_specs/
+    builtin_defaults default to this module's own, but are overridable for a
+    caller (e.g. insert_optimized_media.py) extending them with its own
+    extra options (like "db-path")."""
+    file_overrides = load_config_file(args.config, option_specs) if args.config else {}
+
+    cfg = {}
+    for dest, _converter in option_specs.values():
+        cli_value = getattr(args, dest, None)
+        if cli_value is not None:
+            cfg[dest] = cli_value
+        elif dest in file_overrides:
+            cfg[dest] = file_overrides[dest]
+        elif dest in builtin_defaults:
+            cfg[dest] = builtin_defaults[dest]
+        else:
+            cfg[dest] = None  # input_dir/output_dir: no built-in default
+    return cfg
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    try:
+        cfg = resolve_config(args)
+    except RuntimeError as exc:
+        parser.error(str(exc))
+        return
+
+    if cfg["input_dir"] is None or cfg["output_dir"] is None:
+        parser.error("input_dir and output_dir must be given either as positional arguments or in --config")
+
+    log_file_handle = open(cfg["log_file"], "w", encoding="utf-8") if cfg["log_file"] else None
+    logger = Logger(log_file_handle)
+    try:
+        if not cfg["input_dir"].is_dir():
+            logger.error(f"error: {cfg['input_dir']} is not a directory")
+            sys.exit(1)
+
+        if cfg["verbose"]:
+            logger.info("Config parameters:")
+            for key, (dest, _converter) in OPTION_SPECS.items():
+                logger.info(f"  {key} = {cfg[dest]}")
+            if args.config:
+                logger.info(f"  (loaded from {args.config})")
+
+        try:
+            pngquant_path = find_pngquant()
+        except RuntimeError as exc:
+            logger.error(f"error: {exc}")
+            sys.exit(1)
+
+        stats = {"raster": 0, "svg": 0, "svg_rasterized": 0, "copied": 0, "errors": 0, "original_bytes": 0,
+                  "optimized_bytes": 0}
+        optimize_directory(cfg["input_dir"], cfg["output_dir"], cfg=cfg, pngquant_path=pngquant_path, logger=logger,
+                            stats=stats)
+
+        saved = stats["original_bytes"] - stats["optimized_bytes"]
+        pct = (saved / stats["original_bytes"] * 100) if stats["original_bytes"] else 0.0
+        logger.info(
+            f"Done: {stats['raster']} raster image(s) optimized, {stats['svg']} SVG(s) optimized, "
+            f"{stats['svg_rasterized']} SVG(s) rasterized, {stats['copied']} other file(s) copied, "
+            f"{stats['errors']} error(s). Total size: {stats['original_bytes']:,} -> {stats['optimized_bytes']:,} "
+            f"bytes (saved {saved:,} bytes, {pct:.1f}%)."
+        )
+        if stats["errors"]:
+            sys.exit(1)
+    finally:
+        if log_file_handle is not None:
+            log_file_handle.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/populate_db.py
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/populate_db.py
@@ -1,0 +1,616 @@
+#!/usr/bin/env python3
+"""
+Populates a documentation.db-schema SQLite database with the same content
+templates/page.peb and this project's md_to_json.py conversion pipeline
+produce for the static site, replacing what's currently at k/html/*.
+
+Usage:
+    python3 populate_db.py <docs-root> <config> <images-zip> [db-path]
+        [--tree-file kr.tree] [--topics-subdir topics]
+        [--blacklisted-element-titles "Ancestor\\/.../Element Title" ...]
+
+--blacklisted-element-titles names <toc-element toc-title="..."> element(s)
+to drop from kr.tree entirely before anything else below reads it: the
+element and its whole subtree get no nav entry, none of their .md sub-topics
+get converted or inserted, and any *other*, non-blacklisted page's in-content
+link to one of those .md files renders broken/styled (same as any other
+unresolved link - see broken-ext-link-color) rather than pointing somewhere
+that no longer exists.
+
+Each value is the *full* toc-title path from a top-level <toc-element> down
+to the one being blacklisted, since toc-title alone is not unique across
+kr.tree (e.g. plenty of "Overview"s). Levels are joined by the two-character
+sequence "\\/" (backslash then slash) rather than a bare "/", because a bare
+"/" routinely appears *within* a single real toc-title (e.g. "Swift/
+Objective-C and C interop") and this way that overwhelmingly common case
+needs no escaping at all - only the rare level separator does. So to
+blacklist the "Swift/Objective-C and C interop" element nested under the
+top-level "Interoperability" element, pass
+"Interoperability\\/Swift/Objective-C and C interop": split on "\\/" that's
+["Interoperability", "Swift/Objective-C and C interop"], matching kr.tree's
+actual nesting - the inner "/" is left untouched since it wasn't preceded by
+a backslash.
+
+<db-path> defaults to "documentation.db". A safety backup (via SQLite's
+"VACUUM INTO", which is safe even against a live/WAL-mode database) is
+written next to it before any changes: "<db-path>.backup-<timestamp>".
+
+<images-zip> is Writerside's own official image output for this doc set
+(e.g. "webHelpImages.zip", found next to kr.tree) - a flat archive with no
+subdirectories, one entry per image, already exactly as Writerside itself
+would serve them. Rather than re-deriving image content/sizing ourselves
+from the raw source tree (which is a plain, uncompressed truecolor export -
+several times larger than what a real Writerside build actually ships,
+since it applies its own image optimization we have no easy way to
+replicate faithfully), this script just copies that zip's entries in
+directly, so k/html/images/<name> ends up byte-for-byte what Writerside
+itself produces.
+
+What this does, inside a single transaction (rolled back on any error):
+  1. Deletes every Content row with path LIKE 'k/html/%' or 'assets/%' - the
+     former includes the existing *.html doc pages AND everything else
+     parked there (images, the old Writerside JS bundle under
+     k/html/frontend/, none of which this script replaces); the latter is
+     wherever a previous run of this script put images/CSS/JS, all of
+     which get freshly re-inserted below.
+  2. Upserts templates/page.peb and templates/nav.peb into Templates.
+     page.peb's <aside id="sidebar"> is adapted for this deployment: rather
+     than a build-time {% include "nav.html" %} (this server's Pebble
+     templates are fully self-contained - see the existing "layout.pebble"
+     row, which has no includes at all), it's rendered empty with a
+     data-nav-src attribute, and assets/sidebar.js fetches + injects the
+     nav content client-side once the page loads. nav.peb itself needs no
+     changes for this - see the next point.
+  3. Converts every topic .md file the same way md_to_json.py does (same
+     Converter, same config-driven link/image coloring), except every
+     internal link/image is resolved against "k/html/" instead of "/" - so
+     the exact same page ids from kr.tree/topics/ can be reused unmodified
+     as nav.json's node ids, and templates/nav.peb's existing
+     href="/{{ node.id }}.html" naturally produces the right k/html/ URLs
+     with no template changes needed. Old page paths were flat
+     ("k/html/books.html", no subfolders) even for topics nested under a
+     subdirectory in the source tree (e.g. "tour/kotlin-tour-hello-world.md"),
+     so ids are flattened to their bare filename stem to match that old
+     convention (filenames are already unique across the whole topics/ tree).
+     Images resolve the same way, flattened to their bare filename to match
+     <images-zip>'s own flat layout - the same convention Writerside itself
+     uses to resolve a bare "foo.png" reference in the first place.
+     Also synthesizes an empty placeholder page (no title, no blocks) at
+     k/html/home.html, since kr.tree's start page (home.topic) isn't a .md
+     file and so never goes through this conversion - without it, nav's
+     "Home" link had nowhere to go. It still renders through page.peb, so
+     the sidebar nav shows up on it like any other page.
+  4. Inserts one Content row per page at k/html/<flattened-id>.html,
+     JSON-encoded and brotli-compressed, with prev/next computed from
+     kr.tree's document order, the same way RenderDocs.java does it for the
+     static site. contentTypeID is the "text/html" row (12|text/html|brotli),
+     not "application/json": the stored bytes are JSON, but templateId
+     points the server at page.peb to render that JSON into HTML before a
+     browser ever sees it, so the Content-Type the server actually sends
+     back should describe that rendered output, not the storage format.
+  5. Builds the same navigation tree build_nav.py does from kr.tree, and
+     inserts it as one more Content row (see NAV_CONTENT_PATH below),
+     associated with the nav.peb template and the same "text/html"
+     contentTypeID as every page, for the same reason.
+  6. Inserts every entry in <images-zip> at k/html/images/<name>, and
+     assets/docs.css, assets/tabs.js, assets/sidebar.js at "assets/<name>"
+     (matching page.peb's own href/src for them). All as raw, untemplated
+     Content rows (templateId 0), content-type/compression looked up from
+     ContentTypes by file extension.
+  7. Runs VACUUM on the database (outside the transaction above - SQLite
+     refuses to VACUUM inside one). Deleting/replacing rows only ever frees
+     internal pages for future reuse, it never shrinks the file on disk, so
+     without this the file keeps growing over repeated runs even when the
+     actual data gets smaller.
+
+Every one of those inserts goes through insert_chunked_content, which splits
+anything over 1,048,576 bytes (post-compression) into that many-byte
+fragments stored as additional rows at "<path>-1", "<path>-2", ... - the
+exact scheme WebServer.kt's request handler expects (see CHUNK_SIZE): it
+detects a fragmented row purely by the first row's content being exactly
+that many bytes, then keeps requesting "<path>-N" for increasing N until it
+gets either a shorter fragment or a missing row. Every file that ended up
+chunked is logged by name at the end of the run.
+"""
+import argparse
+import json
+import shutil
+import sqlite3
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+import zipfile
+from datetime import datetime
+from pathlib import Path
+
+import brotli
+
+from build_nav import build_node
+from md_to_json import (
+    Converter,
+    build_topic_index,
+    load_config,
+    load_variables,
+    make_markdown_it,
+)
+
+NAV_CONTENT_PATH = "k/html/_nav.html"
+# Content.path prefix images are stored under, and the URL prefix baked into
+# every "src=" reference to one of them at conversion time (see Converter's
+# image_url_prefix) - the same string except for the leading "/", since
+# Content.path values never have one. Shared with insert_optimized_media.py,
+# which reinserts these same rows after an out-of-band optimization pass.
+IMAGES_DB_PATH_PREFIX = "k/html/images/"
+IMAGES_URL_PREFIX = f"/{IMAGES_DB_PATH_PREFIX}"
+# Page/nav rows store JSON, but templateId points the server at page.peb/
+# nav.peb to render that JSON into HTML before it ever reaches a browser -
+# so the Content-Type the server actually sends back should describe that
+# rendered output (text/html), not the JSON it's stored as internally.
+PAGE_CONTENT_TYPE = "text/html"
+
+# Must match WebServer.kt's "contentChunkSize" exactly (1024 * 1024): its
+# request handler decides a row is fragmented purely by the first row's
+# content being exactly this many bytes, so this can't just be "close to
+# 1MB" - it has to be the identical constant on both sides.
+CHUNK_SIZE = 1024 * 1024
+LANGUAGE = "en-US"
+
+PAGE_PEB_STATIC_ASIDE = '  <aside class="docs-sidebar" id="sidebar">\n    {% include "nav.html" %}\n  </aside>'
+HOME_PAGE_ID = "k/html/home"
+
+# File extension -> ContentTypes.value, for the raw (untemplated) files
+# inserted alongside the JSON pages: images from <images-zip> and page.peb's
+# own CSS/JS. Compression is looked up from ContentTypes itself
+# (get_content_type below) rather than assumed here, so it always matches
+# whatever this database actually declares.
+EXTENSION_TO_CONTENT_TYPE = {
+    ".png": "image/png",
+    ".svg": "image/svg+xml",
+    ".gif": "image/gif",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".css": "text/css",
+    ".js": "text/javascript",
+}
+
+# pngquant is a lossy PNG-only compressor; it can't touch svg/gif/jpeg, so
+# this is the only content type run through it before insertion.
+PNGQUANT_CONTENT_TYPE = "image/png"
+PNGQUANT_QUALITY = "65-80"
+
+
+def find_pngquant() -> str:
+    """Locates the pngquant executable on PATH. Raises if it's missing,
+    rather than silently inserting uncompressed PNGs - that'd be a silent
+    regression in output size that's easy to miss."""
+    path = shutil.which("pngquant")
+    if path is None:
+        raise RuntimeError("pngquant not found on PATH; install it (e.g. `apt install pngquant`) and retry")
+    return path
+
+
+def compress_png_with_pngquant(data: bytes, pngquant_path: str, name: str) -> bytes:
+    """Runs pngquant on a single PNG's raw bytes (stdin -> stdout, no temp
+    files), returning the compressed bytes. Falls back to the original bytes
+    unchanged if pngquant declines to compress this particular image (e.g.
+    its exit code 99 means the result would fall below --quality's floor) or
+    otherwise fails, since a slightly larger PNG beats a missing/corrupt one."""
+    result = subprocess.run(
+        [pngquant_path, "--quality", PNGQUANT_QUALITY, "--strip", "--force", "--output", "-", "-"],
+        input=data, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=False,
+    )
+    if result.returncode != 0 or not result.stdout:
+        print(
+            f"warning: pngquant declined to compress {name!r} "
+            f"(exit {result.returncode}: {result.stderr.decode(errors='replace').strip()}); keeping original",
+            file=sys.stderr,
+        )
+        return data
+    return result.stdout
+
+
+def backup_database(db_path: Path) -> Path:
+    timestamp = datetime.now().strftime("%Y%m%d-%H%M%S")
+    backup_path = db_path.with_name(f"{db_path.name}.backup-{timestamp}")
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute("VACUUM INTO ?", (str(backup_path),))
+    finally:
+        conn.close()
+    return backup_path
+
+
+def flatten_to_db_ids(stem_to_id: dict) -> dict:
+    """Bare filename stem -> "k/html/<stem>" (no ".html"), matching the old
+    flat k/html/*.html convention - and, since it's exactly what
+    templates/nav.peb's href="/{{ node.id }}.html" expects, that template
+    needs no changes to produce correct URLs against this database."""
+    return {stem: f"k/html/{stem}" for stem in stem_to_id}
+
+
+def load_zip_image_names(images_zip: Path) -> list:
+    with zipfile.ZipFile(images_zip) as zf:
+        return sorted(name for name in zf.namelist() if not name.endswith("/"))
+
+
+def get_id(conn, table: str, value: str) -> int:
+    row = conn.execute(f"SELECT id FROM {table} WHERE value = ?", (value,)).fetchone()
+    if row is None:
+        raise RuntimeError(f"{table} has no row for {value!r}; expected it to already exist in this database")
+    return row[0]
+
+
+def get_content_type(conn, value: str) -> tuple:
+    """Returns (id, compress) for a ContentTypes.value, compress being
+    whether its declared compression column says "brotli" (anything else,
+    e.g. "none", means store the bytes as-is)."""
+    row = conn.execute("SELECT id, compression FROM ContentTypes WHERE value = ?", (value,)).fetchone()
+    if row is None:
+        raise RuntimeError(f"ContentTypes has no row for {value!r}; expected it to already exist in this database")
+    return row[0], row[1] == "brotli"
+
+
+def insert_chunked_content(conn, path: str, language_id: int, content_type_id: int, template_id: int,
+                            data: bytes, chunked_log: list) -> None:
+    """Inserts `data` (already fully compressed, if applicable - chunking
+    happens on the final bytes, matching WebServer.kt reassembling fragments
+    before ever decompressing) at `path`, splitting anything over
+    CHUNK_SIZE into that many-byte fragments stored as additional rows at
+    "<path>-1", "<path>-2", ... - see CHUNK_SIZE's own comment for why the
+    boundary has to be exact. Every fragment reuses the first row's
+    languageID/contentTypeID/templateId for consistency, though the server
+    only ever reads those columns off the first row - fragment rows are
+    fetched by path alone. Appends (path, total size, chunk count) to
+    chunked_log for anything that needed more than one row."""
+    conn.execute(
+        "INSERT INTO Content (path, languageID, content, contentTypeID, templateId) VALUES (?, ?, ?, ?, ?)",
+        (path, language_id, data[:CHUNK_SIZE], content_type_id, template_id),
+    )
+    if len(data) <= CHUNK_SIZE:
+        return
+
+    fragment_number = 1
+    offset = CHUNK_SIZE
+    while offset < len(data):
+        conn.execute(
+            "INSERT INTO Content (path, languageID, content, contentTypeID, templateId) VALUES (?, ?, ?, ?, ?)",
+            (f"{path}-{fragment_number}", language_id, data[offset:offset + CHUNK_SIZE], content_type_id, template_id),
+        )
+        offset += CHUNK_SIZE
+        fragment_number += 1
+    chunked_log.append((path, len(data), fragment_number))  # fragment_number == total chunk count here
+
+
+def insert_file(conn, data: bytes, name: str, db_path: str, language_id: int, content_type_cache: dict,
+                 chunked_log: list, pngquant_path: str) -> bool:
+    """Inserts one raw (templateId 0) file's bytes as a Content row (chunked
+    via insert_chunked_content if needed). name is only used to look up its
+    content type by extension. Returns False (and skips it, with a warning)
+    for an extension not in EXTENSION_TO_CONTENT_TYPE instead of guessing at
+    a content type. PNGs are run through pngquant first - the only content
+    type it's compatible with - before the usual brotli compression."""
+    content_type_value = EXTENSION_TO_CONTENT_TYPE.get(Path(name).suffix.lower())
+    if content_type_value is None:
+        print(f"warning: no known content type for {name!r}; skipping", file=sys.stderr)
+        return False
+    if content_type_value not in content_type_cache:
+        content_type_cache[content_type_value] = get_content_type(conn, content_type_value)
+    content_type_id, compress = content_type_cache[content_type_value]
+
+    if content_type_value == PNGQUANT_CONTENT_TYPE:
+        data = compress_png_with_pngquant(data, pngquant_path, name)
+    if compress:
+        data = brotli.compress(data)
+    insert_chunked_content(conn, db_path, language_id, content_type_id, 0, data, chunked_log)
+    return True
+
+
+def upsert_template(conn, name: str, content: str) -> int:
+    conn.execute(
+        "INSERT INTO Templates (name, content) VALUES (?, ?) "
+        "ON CONFLICT(name) DO UPDATE SET content = excluded.content",
+        (name, content.encode("utf-8")),
+    )
+    return conn.execute("SELECT id FROM Templates WHERE name = ?", (name,)).fetchone()[0]
+
+
+def build_db_page_template(page_peb_path: Path) -> str:
+    text = page_peb_path.read_text(encoding="utf-8")
+    if PAGE_PEB_STATIC_ASIDE not in text:
+        raise RuntimeError(
+            f"{page_peb_path} no longer contains the expected sidebar <aside> block; "
+            "update build_db_page_template()/PAGE_PEB_STATIC_ASIDE to match its new shape"
+        )
+    db_snippet = f'  <aside class="docs-sidebar" id="sidebar" data-nav-src="/{NAV_CONTENT_PATH}"></aside>'
+    return text.replace(PAGE_PEB_STATIC_ASIDE, db_snippet)
+
+
+def flatten_nav_ids(nodes: list) -> list:
+    """Depth-first walk of the nav tree, in document order, collecting only linkable (id-bearing) nodes."""
+    flat = []
+    for node in nodes:
+        if node["id"] is not None:
+            flat.append(node)
+        flat.extend(flatten_nav_ids(node["children"]))
+    return flat
+
+
+def collect_md_stems(el: ET.Element) -> set:
+    """Returns the bare .md stem (e.g. "native-objc-interop") of el's own
+    topic="...md", if any, plus every descendant toc-element's, recursively -
+    used by prune_blacklisted_elements to know every page a removed subtree
+    was making available."""
+    stems = set()
+    topic = el.get("topic")
+    if topic and topic.endswith(".md"):
+        stems.add(Path(topic).stem)
+    for child in el.findall("toc-element"):
+        stems |= collect_md_stems(child)
+    return stems
+
+
+def parse_blacklist_path(raw: str) -> tuple:
+    """Splits one --blacklisted-element-titles value into its ordered
+    toc-title path components, e.g. "Interoperability\\/Swift/Objective-C
+    and C interop" -> ("Interoperability", "Swift/Objective-C and C
+    interop"). Levels are joined by the two-character sequence "\\/"
+    (backslash then slash) rather than a bare "/", since a bare "/"
+    routinely appears *within* a single real toc-title (as in that example
+    itself) - splitting on the rarer, explicitly-marked separator means the
+    overwhelmingly common case needs no escaping at all."""
+    return tuple(raw.split("\\/"))
+
+
+def prune_blacklisted_elements(root: ET.Element, blacklisted_paths: set) -> tuple:
+    """Removes every <toc-element> whose *full* toc-title path from a
+    top-level element down to itself (see parse_blacklist_path) is in
+    blacklisted_paths - along with all of its descendants - wherever it
+    appears in the tree, mutating root in place. A full path is required
+    (rather than matching toc-title alone) because toc-title is not unique
+    across kr.tree (e.g. plenty of "Overview"s share the string). A match is
+    not searched for *within* an already-removed subtree, since it's gone
+    either way.
+
+    Returns (removed_stems, unmatched_paths): removed_stems is the set of
+    bare .md stems (see collect_md_stems) that no longer have a home in the
+    tree, across every matched subtree combined - callers use this to keep
+    conversion and topic_index consistent with the now-pruned tree (nav
+    itself just naturally no longer mentions them, since they're gone from
+    the tree build_node walks). unmatched_paths is whatever blacklisted path
+    never matched any toc-element, so callers can warn about likely typos
+    (or a wrong ancestor chain) instead of silently doing nothing.
+    """
+    removed_stems = set()
+    matched_paths = set()
+
+    def walk(el: ET.Element, prefix: tuple) -> None:
+        for child in list(el):
+            if child.tag != "toc-element":
+                continue
+            path = prefix + (child.get("toc-title"),)
+            if path in blacklisted_paths:
+                matched_paths.add(path)
+                removed_stems.update(collect_md_stems(child))
+                el.remove(child)
+            else:
+                walk(child, path)
+
+    walk(root, ())
+    return removed_stems, blacklisted_paths - matched_paths
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("docs_root", type=Path, help="Path to kotlin-web-site/docs")
+    parser.add_argument("config", type=Path,
+                         help='Path to a JSON config with "broken-ext-link-color" and "menu-no-link-color"')
+    parser.add_argument("images_zip", type=Path,
+                         help='Writerside\'s own image output zip (e.g. "webHelpImages.zip")')
+    parser.add_argument("db_path", type=Path, nargs="?", default=Path("documentation.db"),
+                         help="SQLite database to populate (default: documentation.db)")
+    parser.add_argument("--tree-file", default="kr.tree", help="Filename of the Writerside tree file under docs_root")
+    parser.add_argument("--topics-subdir", default="topics", help="Subdirectory of docs_root holding .md files")
+    parser.add_argument(
+        "--blacklisted-element-titles", dest="blacklisted_element_titles", nargs="*", default=[], metavar="TOC_PATH",
+        help='full toc-title path(s) of <toc-element>s to omit entirely, from a top-level element down to the '
+             'one being blacklisted, levels joined by "\\/" (e.g. "Interoperability\\/Swift/Objective-C and C '
+             'interop" - note the plain "/" left as-is within that last title itself): the element and its whole '
+             "subtree get no nav entry, none of their .md sub-topics get converted/inserted, and any other page's "
+             "in-content link to one of those .md files renders as broken",
+    )
+    args = parser.parse_args()
+
+    docs_root: Path = args.docs_root
+    topics_dir = docs_root / args.topics_subdir
+    tree_path = docs_root / args.tree_file
+    page_peb_path = Path(__file__).parent / "templates" / "page.peb"
+    nav_peb_path = Path(__file__).parent / "templates" / "nav.peb"
+    assets_dir = Path(__file__).parent / "assets"
+
+    for required in (topics_dir, tree_path, page_peb_path, nav_peb_path, assets_dir, args.config, args.images_zip):
+        if not required.exists():
+            print(f"error: {required} does not exist", file=sys.stderr)
+            sys.exit(1)
+    if not args.db_path.is_file():
+        print(f"error: {args.db_path} does not exist", file=sys.stderr)
+        sys.exit(1)
+
+    pngquant_path = find_pngquant()
+
+    print(f"Backing up {args.db_path}...", file=sys.stderr)
+    backup_path = backup_database(args.db_path)
+    print(f"Backup written to {backup_path}", file=sys.stderr)
+
+    config = load_config(args.config)
+    variables = load_variables(docs_root)
+    topic_index = build_topic_index(topics_dir)  # stem -> nested id, e.g. "tour/kotlin-tour-hello-world"
+    topic_index_db = flatten_to_db_ids(topic_index)  # stem -> "k/html/<stem>"
+
+    # Parsed (and pruned) up front, before topic_index_db/Converter are set
+    # up, so every later stage - conversion, link resolution, nav - agrees on
+    # what no longer exists. Pruning mutates root in place; build_node below
+    # reuses this same, already-pruned root rather than re-parsing tree_path.
+    root = ET.parse(tree_path).getroot()
+    blacklisted_paths = {parse_blacklist_path(raw) for raw in args.blacklisted_element_titles}
+    blacklisted_stems, unmatched_paths = prune_blacklisted_elements(root, blacklisted_paths)
+    for path in sorted(unmatched_paths):
+        print(f"warning: --blacklisted-element-titles {' > '.join(path)!r} matched no <toc-element> in {tree_path}",
+              file=sys.stderr)
+    for stem in blacklisted_stems:
+        topic_index_db.pop(stem, None)  # makes resolve_href treat any link to it as unresolved -> styled broken
+    if blacklisted_stems:
+        print(f"Blacklisted {len(blacklisted_paths) - len(unmatched_paths)} element(s), "
+              f"excluding {len(blacklisted_stems)} topic(s) from nav/conversion: {sorted(blacklisted_stems)}",
+              file=sys.stderr)
+
+    image_names = load_zip_image_names(args.images_zip)
+    image_index_db = {name: name for name in image_names}  # flat, matching the zip's own layout
+    md = make_markdown_it()
+    converter = Converter(
+        md, variables, topic_index_db, image_index_db,
+        broken_ext_link_color=config.get("broken-ext-link-color"),
+        image_url_prefix=IMAGES_URL_PREFIX,
+    )
+
+    md_files = [p for p in sorted(topics_dir.rglob("*.md")) if p.stem not in blacklisted_stems]
+    pages = []
+    for md_path in md_files:
+        rel = md_path.relative_to(topics_dir)
+        db_id = f"k/html/{md_path.stem}"
+        source_rel = str(Path(args.topics_subdir) / rel)
+        try:
+            page = converter.convert_file(md_path, db_id, source_rel)
+        except Exception as exc:  # noqa: BLE001 - surface which file broke, keep converting the rest
+            print(f"error converting {md_path}: {exc}", file=sys.stderr)
+            continue
+        pages.append(page)
+    print(f"Converted {len(pages)}/{len(md_files)} pages", file=sys.stderr)
+
+    # kr.tree's start-page is home.topic, not a .md file, so it never goes
+    # through the conversion loop above - nav ends up linking to
+    # k/html/home.html with no page actually there. Insert an empty
+    # placeholder for it (no title, no blocks) so that link resolves to a
+    # real page instead of 404ing; it's still rendered through page.peb, so
+    # the sidebar nav appears on it exactly like any other page.
+    pages.append({"id": HOME_PAGE_ID, "sourceFile": None, "title": None, "blocks": []})
+    topic_index_db["home"] = HOME_PAGE_ID  # lets build_node resolve home.topic as a real link below
+
+    id_to_title = {p["id"]: p["title"] for p in pages}
+    nav_warnings = []
+    nav_tree = [
+        build_node(el, topic_index_db, id_to_title, nav_warnings, config.get("menu-no-link-color"),
+                   id_prefix="k/html/")
+        for el in root.findall("toc-element")
+    ]
+    nav_tree = [node for node in nav_tree if node is not None]
+    for w in nav_warnings:
+        print(f"warning: {w}", file=sys.stderr)
+
+    flat_nav = flatten_nav_ids(nav_tree)
+    id_to_index = {}
+    for i, node in enumerate(flat_nav):
+        id_to_index.setdefault(node["id"], i)
+    for page in pages:
+        idx = id_to_index.get(page["id"])
+        if idx is None:
+            continue
+        if idx > 0:
+            prev_node = flat_nav[idx - 1]
+            page["prev"] = {"id": prev_node["id"], "title": prev_node["title"]}
+        if idx < len(flat_nav) - 1:
+            next_node = flat_nav[idx + 1]
+            page["next"] = {"id": next_node["id"], "title": next_node["title"]}
+
+    page_template_content = build_db_page_template(page_peb_path)
+    nav_template_content = nav_peb_path.read_text(encoding="utf-8")
+
+    conn = sqlite3.connect(args.db_path)
+    try:
+        conn.execute("BEGIN")
+        deleted = conn.execute("DELETE FROM Content WHERE path LIKE 'k/html/%' OR path LIKE 'assets/%'").rowcount
+        print(f"Deleted {deleted} existing k/html/ and assets/ row(s)", file=sys.stderr)
+
+        page_template_id = upsert_template(conn, "page.peb", page_template_content)
+        nav_template_id = upsert_template(conn, "nav.peb", nav_template_content)
+
+        page_content_type_id = get_id(conn, "ContentTypes", PAGE_CONTENT_TYPE)
+        # WebServer.kt's fragment-continuation query hardcodes "AND
+        # languageId = 1" regardless of the first row's own language, so
+        # every fragment - and thus, to keep this simple, every row this
+        # script writes at all - has to be languageID 1. Only fine because
+        # this database has exactly one language ("en-US") today; would need
+        # a real fix on the server side before a second language could work.
+        language_id = get_id(conn, "Languages", LANGUAGE)
+
+        chunked_log = []
+
+        for page in pages:
+            path = f"{page['id']}.html"
+            blob = brotli.compress(json.dumps(page, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
+            insert_chunked_content(conn, path, language_id, page_content_type_id, page_template_id, blob, chunked_log)
+
+        # The server (see layout.pebble) parses each Content row's JSON as an
+        # object and hands its top-level fields to Pebble directly as the
+        # model - a bare JSON array wouldn't parse that way at all, so the
+        # tree goes under a "tree" key here, matching nav.peb's top-level
+        # "{% for node in tree %}".
+        nav_document = {"tree": nav_tree}
+        nav_blob = brotli.compress(json.dumps(nav_document, separators=(",", ":"), ensure_ascii=False).encode("utf-8"))
+        insert_chunked_content(conn, NAV_CONTENT_PATH, language_id, page_content_type_id, nav_template_id, nav_blob,
+                                chunked_log)
+
+        content_type_cache = {}
+        images_inserted = 0
+        with zipfile.ZipFile(args.images_zip) as zf:
+            for name in image_names:
+                db_path = f"{IMAGES_DB_PATH_PREFIX}{name}"
+                if insert_file(conn, zf.read(name), name, db_path, language_id, content_type_cache, chunked_log,
+                                pngquant_path):
+                    images_inserted += 1
+
+        assets_inserted = 0
+        for asset_path in sorted(assets_dir.iterdir()):
+            if not asset_path.is_file():
+                continue
+            db_path = f"assets/{asset_path.name}"
+            if insert_file(conn, asset_path.read_bytes(), asset_path.name, db_path, language_id, content_type_cache,
+                            chunked_log, pngquant_path):
+                assets_inserted += 1
+
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+    # SQLite never shrinks a database file just because rows were deleted or
+    # replaced with something smaller (auto_vacuum is off here, and even
+    # with it on, freed pages are only reused for future writes, not
+    # returned to the OS) - the freed space just becomes an internal
+    # freelist. VACUUM is the only thing that actually rebuilds the file at
+    # its true minimal size, and it can't run inside the transaction above
+    # (SQLite refuses VACUUM while one is active), so it's a separate step
+    # on its own connection afterwards.
+    print("Vacuuming database to reclaim freed space...", file=sys.stderr)
+    vacuum_conn = sqlite3.connect(args.db_path)
+    try:
+        vacuum_conn.execute("VACUUM")
+    finally:
+        vacuum_conn.close()
+
+    print(
+        f"Inserted {len(pages)} page(s) + 1 navigation row + {images_inserted} image(s) + "
+        f"{assets_inserted} asset file(s) into {args.db_path} "
+        f"(page.peb template id={page_template_id}, nav.peb template id={nav_template_id})"
+    )
+    if chunked_log:
+        print(f"Chunked {len(chunked_log)} file(s) over {CHUNK_SIZE:,} bytes:")
+        for path, total_size, chunk_count in chunked_log:
+            print(f"  {path}: {total_size:,} bytes -> {chunk_count} chunks")
+    else:
+        print(f"No files exceeded {CHUNK_SIZE:,} bytes; nothing needed chunking.")
+
+
+if __name__ == "__main__":
+    main()

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/templates/nav.html
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/templates/nav.html
@@ -1,0 +1,2133 @@
+<nav class="docs-nav" aria-label="Documentation">
+  <ul class="nav-tree">
+  <li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" style="color: #999999;" href="/home.html" data-nav-id="home">Home</a>
+</div>
+</li>
+  <li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/getting-started.html" data-nav-id="getting-started">Get started</a>
+</div>
+</li>
+  <li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Take Kotlin tour section"></button><a class="nav-link" href="/tour/kotlin-tour-welcome.html" data-nav-id="tour/kotlin-tour-welcome">Take Kotlin tour</a>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/tour/kotlin-tour-hello-world.html" data-nav-id="tour/kotlin-tour-hello-world">Hello world</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/tour/kotlin-tour-basic-types.html" data-nav-id="tour/kotlin-tour-basic-types">Basic types</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/tour/kotlin-tour-collections.html" data-nav-id="tour/kotlin-tour-collections">Collections</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/tour/kotlin-tour-control-flow.html" data-nav-id="tour/kotlin-tour-control-flow">Control flow</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/tour/kotlin-tour-functions.html" data-nav-id="tour/kotlin-tour-functions">Functions</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/tour/kotlin-tour-classes.html" data-nav-id="tour/kotlin-tour-classes">Classes</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/tour/kotlin-tour-null-safety.html" data-nav-id="tour/kotlin-tour-null-safety">Null safety</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/tour/kotlin-tour-intermediate-extension-functions.html" data-nav-id="tour/kotlin-tour-intermediate-extension-functions">Intermediate: Extension functions</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/tour/kotlin-tour-intermediate-scope-functions.html" data-nav-id="tour/kotlin-tour-intermediate-scope-functions">Intermediate: Scope functions</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/tour/kotlin-tour-intermediate-lambdas-receiver.html" data-nav-id="tour/kotlin-tour-intermediate-lambdas-receiver">Intermediate: Lambda expressions with receiver</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/tour/kotlin-tour-intermediate-classes-interfaces.html" data-nav-id="tour/kotlin-tour-intermediate-classes-interfaces">Intermediate: Classes and interfaces</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/tour/kotlin-tour-intermediate-objects.html" data-nav-id="tour/kotlin-tour-intermediate-objects">Intermediate: Objects</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/tour/kotlin-tour-intermediate-open-special-classes.html" data-nav-id="tour/kotlin-tour-intermediate-open-special-classes">Intermediate: Open and special classes</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/tour/kotlin-tour-intermediate-properties.html" data-nav-id="tour/kotlin-tour-intermediate-properties">Intermediate: Properties</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/tour/kotlin-tour-intermediate-null-safety.html" data-nav-id="tour/kotlin-tour-intermediate-null-safety">Intermediate: Null safety</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/tour/kotlin-tour-intermediate-libraries-and-apis.html" data-nav-id="tour/kotlin-tour-intermediate-libraries-and-apis">Intermediate: Libraries and APIs</a>
+</div>
+</li>
+</ul>
+</li>
+  <li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle What&#39;s new in Kotlin section"></button><span class="nav-group-title" style="color: #999999;">What&#39;s new in Kotlin</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew-eap.html" data-nav-id="whatsnew/whatsnew-eap">Kotlin 2.4.20-Beta1</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew24.html" data-nav-id="whatsnew/whatsnew24">Kotlin 2.4.0</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compatibility-guides/compatibility-guide-24.html" data-nav-id="compatibility-guides/compatibility-guide-24">Compatibility guide</a>
+</div>
+</li>
+</ul>
+</li>
+  <li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Language guide section"></button><span class="nav-group-title" style="color: #999999;">Language guide</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Basic syntax section"></button><span class="nav-group-title" style="color: #999999;">Basic syntax</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/basic-syntax.html" data-nav-id="basic-syntax">Overview</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/keyword-reference.html" data-nav-id="keyword-reference">Keywords and operators</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/packages.html" data-nav-id="packages">Packages and imports</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/annotations.html" data-nav-id="annotations">Annotations</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/visibility-modifiers.html" data-nav-id="visibility-modifiers">Visibility modifiers</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/coding-conventions.html" data-nav-id="coding-conventions">Coding conventions</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/idioms.html" data-nav-id="idioms">Idioms</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Types section"></button><span class="nav-group-title" style="color: #999999;">Types</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/types-overview.html" data-nav-id="types-overview">Overview</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/numbers.html" data-nav-id="numbers">Numbers</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/unsigned-integer-types.html" data-nav-id="unsigned-integer-types">Unsigned integer types</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/booleans.html" data-nav-id="booleans">Booleans</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/characters.html" data-nav-id="characters">Characters</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/strings.html" data-nav-id="strings">Strings</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/arrays.html" data-nav-id="arrays">Arrays</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/typecasts.html" data-nav-id="typecasts">Type checks and casts</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/type-aliases.html" data-nav-id="type-aliases">Type aliases</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Control flow section"></button><span class="nav-group-title" style="color: #999999;">Control flow</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/control-flow.html" data-nav-id="control-flow">Conditions and loops</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/returns.html" data-nav-id="returns">Returns and jumps</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/exceptions.html" data-nav-id="exceptions">Exception handling</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Functions section"></button><span class="nav-group-title" style="color: #999999;">Functions</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/functions.html" data-nav-id="functions">Functions</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/lambdas.html" data-nav-id="lambdas">Lambdas</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/this-expressions.html" data-nav-id="this-expressions">This expressions</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Builders section"></button><span class="nav-group-title" style="color: #999999;">Builders</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/type-safe-builders.html" data-nav-id="type-safe-builders">Type-safe builders</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/using-builders-with-builder-inference.html" data-nav-id="using-builders-with-builder-inference">Using builders with builder type inference</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/context-parameters.html" data-nav-id="context-parameters">Context parameters</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/inline-functions.html" data-nav-id="inline-functions">Inline functions</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/operator-overloading.html" data-nav-id="operator-overloading">Operator overloading</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/unused-return-value-checker.html" data-nav-id="unused-return-value-checker">Unused return value checker</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Classes and interfaces section"></button><span class="nav-group-title" style="color: #999999;">Classes and interfaces</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/classes.html" data-nav-id="classes">Classes</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/data-classes.html" data-nav-id="data-classes">Data classes</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/extensions.html" data-nav-id="extensions">Extensions</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/interfaces.html" data-nav-id="interfaces">Interfaces</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/delegation.html" data-nav-id="delegation">Delegation</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/inheritance.html" data-nav-id="inheritance">Inheritance</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/object-declarations.html" data-nav-id="object-declarations">Object declarations and expressions</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Special classes and interfaces section"></button><span class="nav-group-title" style="color: #999999;">Special classes and interfaces</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/sealed-classes.html" data-nav-id="sealed-classes">Sealed classes and interfaces</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/enum-classes.html" data-nav-id="enum-classes">Enum classes</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/inline-classes.html" data-nav-id="inline-classes">Inline value classes</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/nested-classes.html" data-nav-id="nested-classes">Nested and inner classes</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/fun-interfaces.html" data-nav-id="fun-interfaces">Functional \(SAM\) interfaces</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Properties section"></button><span class="nav-group-title" style="color: #999999;">Properties</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/properties.html" data-nav-id="properties">Properties</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/delegated-properties.html" data-nav-id="delegated-properties">Delegated properties</a>
+</div>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/null-safety.html" data-nav-id="null-safety">Null safety</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/equality.html" data-nav-id="equality">Equality</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/generics.html" data-nav-id="generics">Generics</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Concurrency section"></button><span class="nav-group-title" style="color: #999999;">Concurrency</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/async-programming.html" data-nav-id="async-programming">Asynchronous programming techniques</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/coroutines-overview.html" data-nav-id="coroutines-overview">Coroutines</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/reflection.html" data-nav-id="reflection">Reflection</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/destructuring-declarations.html" data-nav-id="destructuring-declarations">Destructuring declarations</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Language reference section"></button><span class="nav-group-title" style="color: #999999;">Language reference</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Grammar</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Language specification</span>
+</div>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+  <li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Development section"></button><span class="nav-group-title" style="color: #999999;">Development</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Backend development section"></button><span class="nav-group-title" style="color: #999999;">Backend development</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/jvm/server-overview.html" data-nav-id="jvm/server-overview">Overview</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/jvm/mixing-java-kotlin-intellij.html" data-nav-id="jvm/mixing-java-kotlin-intellij">Add Kotlin to a Java project</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/jvm/jvm-test-using-junit.html" data-nav-id="jvm/jvm-test-using-junit">Test Java code with Kotlin</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/jvm/jvm-test-maven.html" data-nav-id="jvm/jvm-test-maven">Testing with Maven</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/jvm/jvm-annotation-processors.html" data-nav-id="jvm/jvm-annotation-processors">Use annotation processors</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Create a web app with Kotlin and Spring Boot section"></button><span class="nav-group-title" style="color: #999999;">Create a web app with Kotlin and Spring Boot</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/jvm/jvm-get-started-spring-boot.html" data-nav-id="jvm/jvm-get-started-spring-boot">Get started with Spring Boot and Kotlin</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/jvm/jvm-create-project-with-spring-boot.html" data-nav-id="jvm/jvm-create-project-with-spring-boot">Create a Spring Boot project</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/jvm/jvm-spring-boot-add-data-class.html" data-nav-id="jvm/jvm-spring-boot-add-data-class">Upgrade your project with data classes</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/jvm/jvm-spring-boot-add-db-support.html" data-nav-id="jvm/jvm-spring-boot-add-db-support">Add database support for Spring Boot project</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/jvm/jvm-spring-boot-using-crudrepository.html" data-nav-id="jvm/jvm-spring-boot-using-crudrepository">Use Spring Data CrudRepository</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/ai/spring-boot-claude.html" data-nav-id="ai/spring-boot-claude">Create a Kotlin app with Spring Boot and Claude – tutorial</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Web development section"></button><span class="nav-group-title" style="color: #999999;">Web development</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/web-overview.html" data-nav-id="web-overview">Overview</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin/JS section"></button><span class="nav-group-title" style="color: #999999;">Kotlin/JS</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/js/js-overview.html" data-nav-id="js/js-overview">Overview</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/js/js-get-started.html" data-nav-id="js/js-get-started">Get started with Kotlin/JS</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/js/js-project-setup.html" data-nav-id="js/js-project-setup">Set up a Kotlin/JS project</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/js/running-kotlin-js.html" data-nav-id="js/running-kotlin-js">Run Kotlin/JS</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/js/dev-server-continuous-compilation.html" data-nav-id="js/dev-server-continuous-compilation">Development server and continuous compilation</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/js/js-debugging.html" data-nav-id="js/js-debugging">Debug Kotlin/JS code</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/js/js-running-tests.html" data-nav-id="js/js-running-tests">Run tests in Kotlin/JS</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/js/js-frameworks.html" data-nav-id="js/js-frameworks">Kotlin/JS frameworks</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/js/js-ir-compiler.html" data-nav-id="js/js-ir-compiler">Kotlin/JS compiler features</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/js/js-plain-objects.html" data-nav-id="js/js-plain-objects">JS plain objects compiler plugin</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/js/js-react.html" data-nav-id="js/js-react">Build a web application with React and Kotlin/JS — tutorial</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle WebAssembly (Wasm) section"></button><span class="nav-group-title" style="color: #999999;">WebAssembly (Wasm)</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/wasm/wasm-overview.html" data-nav-id="wasm/wasm-overview">Overview</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/wasm/wasm-get-started.html" data-nav-id="wasm/wasm-get-started">Get started with Kotlin/Wasm and Compose Multiplatform</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/wasm/wasm-wasi.html" data-nav-id="wasm/wasm-wasi">Get started with Kotlin/Wasm and WASI</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/wasm/wasm-debugging.html" data-nav-id="wasm/wasm-debugging">Debug Kotlin/Wasm code</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/wasm/wasm-js-interop.html" data-nav-id="wasm/wasm-js-interop">Interoperability with JavaScript</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/wasm/wasm-configuration.html" data-nav-id="wasm/wasm-configuration">Supported versions and configuration</a>
+</div>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Native development section"></button><span class="nav-group-title" style="color: #999999;">Native development</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-overview.html" data-nav-id="native/native-overview">Overview</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-get-started.html" data-nav-id="native/native-get-started">Get started with Kotlin/Native</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-libraries.html" data-nav-id="native/native-libraries">Kotlin/Native libraries</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-platform-libs.html" data-nav-id="native/native-platform-libs">Platform libraries</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Memory manager section"></button><span class="nav-group-title" style="color: #999999;">Memory manager</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-memory-manager.html" data-nav-id="native/native-memory-manager">Kotlin/Native memory management</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-arc-integration.html" data-nav-id="native/native-arc-integration">Integration with ARC</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-migration-guide.html" data-nav-id="native/native-migration-guide">Migration guide</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-binary-options.html" data-nav-id="native/native-binary-options">Binary options</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-debugging.html" data-nav-id="native/native-debugging">Debugging Kotlin/Native</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-target-support.html" data-nav-id="native/native-target-support">Target and host support</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-improving-compilation-time.html" data-nav-id="native/native-improving-compilation-time">Improving compilation time</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-llvm-passes.html" data-nav-id="native/native-llvm-passes">Customizing LLVM passes</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-binary-licenses.html" data-nav-id="native/native-binary-licenses">License files</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-faq.html" data-nav-id="native/native-faq">Kotlin/Native FAQ</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/android-overview.html" data-nav-id="android-overview">Android development</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Designing your library</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/scripting/custom-script-deps-tutorial.html" data-nav-id="scripting/custom-script-deps-tutorial">Kotlin custom scripting</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Development tooling section"></button><span class="nav-group-title" style="color: #999999;">Development tooling</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/kotlin-ide.html" data-nav-id="kotlin-ide">IDE for Kotlin development</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/kotlin-lsp.html" data-nav-id="kotlin-lsp">Kotlin Language Server</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Dokka</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/run-code-snippets.html" data-nav-id="run-code-snippets">Run code snippets</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/kotlin-doc.html" data-nav-id="kotlin-doc">KDoc</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/kotlin-osgi.html" data-nav-id="kotlin-osgi">OSGi</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/kotlin-and-ci.html" data-nav-id="kotlin-and-ci">TeamCity</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/code-style-migration-guide.html" data-nav-id="code-style-migration-guide">Migrate to Kotlin code style with IntelliJ IDEA</a>
+</div>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+  <li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Interoperability section"></button><span class="nav-group-title" style="color: #999999;">Interoperability</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Java interop section"></button><span class="nav-group-title" style="color: #999999;">Java interop</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/jvm/comparison-to-java.html" data-nav-id="jvm/comparison-to-java">Comparison to Java</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/jvm/java-interop.html" data-nav-id="jvm/java-interop">Calling Java from Kotlin</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/jvm/java-to-kotlin-interop.html" data-nav-id="jvm/java-to-kotlin-interop">Calling Kotlin from Java</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/jvm/jvm-records.html" data-nav-id="jvm/jvm-records">Using Java records in Kotlin</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Java to Kotlin migration guides section"></button><span class="nav-group-title" style="color: #999999;">Java to Kotlin migration guides</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/jvm/java-to-kotlin-idioms-strings.html" data-nav-id="jvm/java-to-kotlin-idioms-strings">Strings</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/jvm/java-to-kotlin-collections-guide.html" data-nav-id="jvm/java-to-kotlin-collections-guide">Collections</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/jvm/java-to-kotlin-nullability-guide.html" data-nav-id="jvm/java-to-kotlin-nullability-guide">Nullability</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/standard-input.html" data-nav-id="standard-input">Standard input</a>
+</div>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle JavaScript interop section"></button><span class="nav-group-title" style="color: #999999;">JavaScript interop</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/js/browser-api-dom.html" data-nav-id="js/browser-api-dom">Browser and DOM API</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/js/js-interop.html" data-nav-id="js/js-interop">Use JavaScript code from Kotlin</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/js/dynamic-type.html" data-nav-id="js/dynamic-type">Dynamic type</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/js/using-packages-from-npm.html" data-nav-id="js/using-packages-from-npm">Use dependencies from npm</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/js/js-to-kotlin-interop.html" data-nav-id="js/js-to-kotlin-interop">Use Kotlin code from JavaScript</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/js/js-modules.html" data-nav-id="js/js-modules">JavaScript modules</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/js/js-reflection.html" data-nav-id="js/js-reflection">Kotlin/JS reflection</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/js/typesafe-html-dsl.html" data-nav-id="js/typesafe-html-dsl">Typesafe HTML DSL</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Swift/Objective-C and C interop section"></button><span class="nav-group-title" style="color: #999999;">Swift/Objective-C and C interop</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Swift/Objective-C interop section"></button><span class="nav-group-title" style="color: #999999;">Swift/Objective-C interop</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-objc-interop.html" data-nav-id="native/native-objc-interop">Interoperability with Swift/Objective-C</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/apple-framework.html" data-nav-id="native/apple-framework">Kotlin/Native as an Apple framework – tutorial</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-swift-export.html" data-nav-id="native/native-swift-export">Swift export</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle C interop section"></button><span class="nav-group-title" style="color: #999999;">C interop</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-c-interop.html" data-nav-id="native/native-c-interop">Interoperability with C</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/mapping-primitive-data-types-from-c.html" data-nav-id="native/mapping-primitive-data-types-from-c">Mapping primitive data types from C – tutorial</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/mapping-struct-union-types-from-c.html" data-nav-id="native/mapping-struct-union-types-from-c">Mapping struct and union types from C – tutorial</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/mapping-function-pointers-from-c.html" data-nav-id="native/mapping-function-pointers-from-c">Mapping function pointers from C – tutorial</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/mapping-strings-from-c.html" data-nav-id="native/mapping-strings-from-c">Mapping strings from C – tutorial</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-dynamic-libraries.html" data-nav-id="native/native-dynamic-libraries">Create a dynamic library – tutorial</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-app-with-c-and-libcurl.html" data-nav-id="native/native-app-with-c-and-libcurl">Create an app using C interop and libcurl – tutorial</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-definition-file.html" data-nav-id="native/native-definition-file">Definition file</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/native/native-lib-import-stability.html" data-nav-id="native/native-lib-import-stability">External library import</a>
+</div>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+  <li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin for AI and data analysis section"></button><span class="nav-group-title" style="color: #999999;">Kotlin for AI and data analysis</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin for AI section"></button><span class="nav-group-title" style="color: #999999;">Kotlin for AI</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/ai/kotlin-ai-skills.html" data-nav-id="ai/kotlin-ai-skills">Kotlin AI skills</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/ai/kotlin-ai-apps-development-overview.html" data-nav-id="ai/kotlin-ai-apps-development-overview">Kotlin for AI-powered apps</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/ai/spring-ai-guide.html" data-nav-id="ai/spring-ai-guide">Build a Kotlin app with Spring AI – tutorial</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin for data analysis section"></button><span class="nav-group-title" style="color: #999999;">Kotlin for data analysis</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/data-analysis-overview.html" data-nav-id="data-analysis-overview">Overview</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Working with data sources section"></button><span class="nav-group-title" style="color: #999999;">Working with data sources</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/data-analysis/data-analysis-work-with-data-sources.html" data-nav-id="data-analysis/data-analysis-work-with-data-sources">Retrieve data from files</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/data-analysis/data-analysis-work-with-api.html" data-nav-id="data-analysis/data-analysis-work-with-api">Retrieve data from web sources and APIs</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/data-analysis/data-analysis-connect-to-db.html" data-nav-id="data-analysis/data-analysis-connect-to-db">Connect and retrieve data from databases</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Visualizing data section"></button><span class="nav-group-title" style="color: #999999;">Visualizing data</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/data-analysis/data-analysis-visualization.html" data-nav-id="data-analysis/data-analysis-visualization">With Kandy</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/data-analysis/lets-plot.html" data-nav-id="data-analysis/lets-plot">With Lets-Plot for Kotlin</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/data-analysis/data-analysis-libraries.html" data-nav-id="data-analysis/data-analysis-libraries">Libraries for data analysis</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/kotlin-notebook-overview.html" data-nav-id="kotlin-notebook-overview">Kotlin Notebook overview</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Get started with Kotlin Notebook section"></button><span class="nav-group-title" style="color: #999999;">Get started with Kotlin Notebook</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/data-analysis/get-started-with-kotlin-notebooks.html" data-nav-id="data-analysis/get-started-with-kotlin-notebooks">Introduction to Kotlin Notebook</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/data-analysis/kotlin-notebook-set-up-env.html" data-nav-id="data-analysis/kotlin-notebook-set-up-env">1. Set up an environment</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/data-analysis/kotlin-notebook-create.html" data-nav-id="data-analysis/kotlin-notebook-create">2. Create your first Kotlin Notebook</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/data-analysis/kotlin-notebook-add-dependencies.html" data-nav-id="data-analysis/kotlin-notebook-add-dependencies">3. Add dependencies to a Kotlin Notebook</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/data-analysis/kotlin-notebook-share.html" data-nav-id="data-analysis/kotlin-notebook-share">Share a Kotlin Notebook</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/data-analysis/data-analysis-notebooks-output-formats.html" data-nav-id="data-analysis/data-analysis-notebooks-output-formats">Output formats in Kotlin notebooks</a>
+</div>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+  <li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Library guides section"></button><span class="nav-group-title" style="color: #999999;">Library guides</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Standard library section"></button><span class="nav-group-title" style="color: #999999;">Standard library</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Collections section"></button><span class="nav-group-title" style="color: #999999;">Collections</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/collections-overview.html" data-nav-id="collections-overview">Overview</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/constructing-collections.html" data-nav-id="constructing-collections">Create</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/iterators.html" data-nav-id="iterators">Traverse</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/collection-ordering.html" data-nav-id="collection-ordering">Order</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/collection-grouping.html" data-nav-id="collection-grouping">Group</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/collection-transformations.html" data-nav-id="collection-transformations">Transform</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/collection-filtering.html" data-nav-id="collection-filtering">Filter</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Retrieve section"></button><span class="nav-group-title" style="color: #999999;">Retrieve</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/collection-parts.html" data-nav-id="collection-parts">Retrieve collection parts</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/collection-elements.html" data-nav-id="collection-elements">Retrieve single elements</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Operations and operators section"></button><span class="nav-group-title" style="color: #999999;">Operations and operators</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/collection-operations.html" data-nav-id="collection-operations">Operations overview</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/collection-aggregate.html" data-nav-id="collection-aggregate">Aggregate operations</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/collection-write.html" data-nav-id="collection-write">Write operations</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/list-operations.html" data-nav-id="list-operations">List-specific operations</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/set-operations.html" data-nav-id="set-operations">Set-specific operations</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/map-operations.html" data-nav-id="map-operations">Map-specific operations</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/collection-plus-minus.html" data-nav-id="collection-plus-minus">Plus and minus operators</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/sequences.html" data-nav-id="sequences">Sequences</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/ranges.html" data-nav-id="ranges">Ranges and progressions</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/read-standard-input.html" data-nav-id="read-standard-input">Read standard input</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/opt-in-requirements.html" data-nav-id="opt-in-requirements">Opt-in requirements</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/scope-functions.html" data-nav-id="scope-functions">Scope functions</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/time-measurement.html" data-nav-id="time-measurement">Time measurement</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/uuids.html" data-nav-id="uuids">UUIDs</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Coroutines (kotlinx.coroutines)</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Serialization (kotlinx.serialization)</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/metadata-jvm.html" data-nav-id="metadata-jvm">Kotlin Metadata JVM (kotlin-metadata-jvm)</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Lincheck (kotlinx.lincheck)</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Ktor</span>
+</div>
+</li>
+</ul>
+</li>
+  <li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle API reference section"></button><span class="nav-group-title" style="color: #999999;">API reference</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" style="color: #999999;" href="/api-references.html" data-nav-id="api-references">Overview</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Standard library (stdlib)</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Test library (kotlin.test)</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Coroutines (kotlinx.coroutines)</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Serialization (kotlinx.serialization)</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Kotlin I/O library (kotlinx-io)</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Date and time (kotlinx-datetime)</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Immutable collections (kotlinx.collections.immutable)</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">JVM Metadata (kotlinx-metadata-jvm)</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Ktor</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Kotlin Gradle plugins (kotlin-gradle-plugin)</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Compose Multiplatform Material3</span>
+</div>
+</li>
+</ul>
+</li>
+  <li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Build tools section"></button><span class="nav-group-title" style="color: #999999;">Build tools</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Gradle section"></button><span class="nav-group-title" style="color: #999999;">Gradle</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/gradle/gradle.html" data-nav-id="gradle/gradle">Overview</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/gradle/get-started-with-jvm-gradle-project.html" data-nav-id="gradle/get-started-with-jvm-gradle-project">Get started with Gradle – tutorial</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/gradle/gradle-configure-project.html" data-nav-id="gradle/gradle-configure-project">Configure a Gradle project</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/gradle/gradle-best-practices.html" data-nav-id="gradle/gradle-best-practices">Gradle best practices</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/gradle/gradle-compiler-options.html" data-nav-id="gradle/gradle-compiler-options">Compiler options in KGP</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/gradle/gradle-compilation-and-caches.html" data-nav-id="gradle/gradle-compilation-and-caches">Compilation and caches in KGP</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Multiplatform Gradle DSL</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/gradle/gradle-binary-compatibility-validation.html" data-nav-id="gradle/gradle-binary-compatibility-validation">Binary compatibility validation in KGP</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/gradle/gradle-plugin-variants.html" data-nav-id="gradle/gradle-plugin-variants">Support for Gradle plugin variants</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Maven section"></button><span class="nav-group-title" style="color: #999999;">Maven</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/maven/maven.html" data-nav-id="maven/maven">Overview</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/maven/maven-configure-project.html" data-nav-id="maven/maven-configure-project">Configure project</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/maven/maven-set-dependencies.html" data-nav-id="maven/maven-set-dependencies">Set repositories and dependencies</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/maven/maven-kotlin-compiler.html" data-nav-id="maven/maven-kotlin-compiler">Configure Kotlin compiler</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/maven/maven-compile-package.html" data-nav-id="maven/maven-compile-package">Package your project</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/build-tools-api.html" data-nav-id="build-tools-api">Build tools API</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/kotlin-daemon.html" data-nav-id="kotlin-daemon">Kotlin daemon</a>
+</div>
+</li>
+</ul>
+</li>
+  <li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Compiler and plugins section"></button><span class="nav-group-title" style="color: #999999;">Compiler and plugins</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin compiler section"></button><span class="nav-group-title" style="color: #999999;">Kotlin compiler</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compiler/k2-compiler-migration-guide.html" data-nav-id="compiler/k2-compiler-migration-guide">K2 compiler migration guide</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compiler/command-line.html" data-nav-id="compiler/command-line">Command-line compiler</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/jvm/jvm-get-started.html" data-nav-id="jvm/jvm-get-started">Create a console app</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compiler/compiler-reference.html" data-nav-id="compiler/compiler-reference">Compiler options</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compiler/compiler-execution-strategy.html" data-nav-id="compiler/compiler-execution-strategy">Compiler execution strategy</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin compiler plugins section"></button><span class="nav-group-title" style="color: #999999;">Kotlin compiler plugins</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compiler-plugins/compiler-plugins-overview.html" data-nav-id="compiler-plugins/compiler-plugins-overview">Overview</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compiler-plugins/all-open-plugin.html" data-nav-id="compiler-plugins/all-open-plugin">All-open</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compiler-plugins/kapt.html" data-nav-id="compiler-plugins/kapt">kapt</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compiler-plugins/lombok.html" data-nav-id="compiler-plugins/lombok">Lombok</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compiler-plugins/no-arg-plugin.html" data-nav-id="compiler-plugins/no-arg-plugin">No-arg</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compiler-plugins/power-assert.html" data-nav-id="compiler-plugins/power-assert">Power-assert</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compiler-plugins/sam-with-receiver-plugin.html" data-nav-id="compiler-plugins/sam-with-receiver-plugin">SAM with receiver</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compiler-plugins/custom-compiler-plugins.html" data-nav-id="compiler-plugins/custom-compiler-plugins">Custom compiler plugins</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Compose compiler section"></button><span class="nav-group-title" style="color: #999999;">Compose compiler</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compose-compiler-migration-guide.html" data-nav-id="compose-compiler-migration-guide">Compiler migration guide</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compose-compiler-options.html" data-nav-id="compose-compiler-options">Compiler options</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin Symbol Processing API section"></button><span class="nav-group-title" style="color: #999999;">Kotlin Symbol Processing API</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/ksp/ksp-overview.html" data-nav-id="ksp/ksp-overview">KSP overview</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/ksp/ksp-quickstart.html" data-nav-id="ksp/ksp-quickstart">Getting started</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/ksp/ksp-why-ksp.html" data-nav-id="ksp/ksp-why-ksp">Why KSP</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/ksp/ksp-kapt-migration.html" data-nav-id="ksp/ksp-kapt-migration">Migrate from kapt to KSP</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/ksp/ksp-examples.html" data-nav-id="ksp/ksp-examples">Examples</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/ksp/ksp-additional-details.html" data-nav-id="ksp/ksp-additional-details">How KSP models Kotlin code</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/ksp/ksp-reference.html" data-nav-id="ksp/ksp-reference">Reference for Java annotation processor authors</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/ksp/ksp-incremental.html" data-nav-id="ksp/ksp-incremental">Incremental processing</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/ksp/ksp-multi-round.html" data-nav-id="ksp/ksp-multi-round">Multiple-round processing</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/ksp/ksp-multiplatform.html" data-nav-id="ksp/ksp-multiplatform">KSP with Kotlin Multiplatform</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Running KSP from the command line</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/ksp/ksp-faq.html" data-nav-id="ksp/ksp-faq">FAQ</a>
+</div>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+  <li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin evolution and roadmap section"></button><span class="nav-group-title" style="color: #999999;">Kotlin evolution and roadmap</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/roadmap.html" data-nav-id="roadmap">Kotlin roadmap</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/kotlin-language-features-and-proposals.html" data-nav-id="kotlin-language-features-and-proposals">Language features and proposals</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/kotlin-evolution-principles.html" data-nav-id="kotlin-evolution-principles">Language evolution principles</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/components-stability.html" data-nav-id="components-stability">Stability of Kotlin components</a>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/components-stability-pre-1.4.html" data-nav-id="components-stability-pre-1.4">Stability of Kotlin components \(pre 1.4\)</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/releases.html" data-nav-id="releases">Kotlin release process</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Earlier Kotlin releases section"></button><span class="nav-group-title" style="color: #999999;">Earlier Kotlin releases</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin 2.3.x section"></button><span class="nav-group-title" style="color: #999999;">Kotlin 2.3.x</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew2320.html" data-nav-id="whatsnew/whatsnew2320">Kotlin 2.3.20</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew23.html" data-nav-id="whatsnew/whatsnew23">Kotlin 2.3.0</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compatibility-guides/compatibility-guide-23.html" data-nav-id="compatibility-guides/compatibility-guide-23">Compatibility guide</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin 2.2.x section"></button><span class="nav-group-title" style="color: #999999;">Kotlin 2.2.x</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew2220.html" data-nav-id="whatsnew/whatsnew2220">Kotlin 2.2.20</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew22.html" data-nav-id="whatsnew/whatsnew22">Kotlin 2.2.0</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compatibility-guides/compatibility-guide-22.html" data-nav-id="compatibility-guides/compatibility-guide-22">Compatibility guide</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin 2.1.x section"></button><span class="nav-group-title" style="color: #999999;">Kotlin 2.1.x</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew2120.html" data-nav-id="whatsnew/whatsnew2120">Kotlin 2.1.20</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew21.html" data-nav-id="whatsnew/whatsnew21">Kotlin 2.1.0</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compatibility-guides/compatibility-guide-21.html" data-nav-id="compatibility-guides/compatibility-guide-21">Compatibility guide</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin 2.0.x section"></button><span class="nav-group-title" style="color: #999999;">Kotlin 2.0.x</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew2020.html" data-nav-id="whatsnew/whatsnew2020">Kotlin 2.0.20</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew20.html" data-nav-id="whatsnew/whatsnew20">Kotlin 2.0.0</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compatibility-guides/compatibility-guide-20.html" data-nav-id="compatibility-guides/compatibility-guide-20">Compatibility guide</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin 1.9.x section"></button><span class="nav-group-title" style="color: #999999;">Kotlin 1.9.x</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew1920.html" data-nav-id="whatsnew/whatsnew1920">Kotlin 1.9.20</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew19.html" data-nav-id="whatsnew/whatsnew19">Kotlin 1.9.0</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compatibility-guides/compatibility-guide-19.html" data-nav-id="compatibility-guides/compatibility-guide-19">Compatibility guide</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin 1.8.x section"></button><span class="nav-group-title" style="color: #999999;">Kotlin 1.8.x</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew1820.html" data-nav-id="whatsnew/whatsnew1820">Kotlin 1.8.20</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew18.html" data-nav-id="whatsnew/whatsnew18">Kotlin 1.8.0</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compatibility-guides/compatibility-guide-18.html" data-nav-id="compatibility-guides/compatibility-guide-18">Compatibility guide</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin 1.7.x section"></button><span class="nav-group-title" style="color: #999999;">Kotlin 1.7.x</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew1720.html" data-nav-id="whatsnew/whatsnew1720">Kotlin 1.7.20</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew17.html" data-nav-id="whatsnew/whatsnew17">Kotlin 1.7.0</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compatibility-guides/compatibility-guide-1720.html" data-nav-id="compatibility-guides/compatibility-guide-1720">Compatibility guide for Kotlin 1.7.20</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compatibility-guides/compatibility-guide-17.html" data-nav-id="compatibility-guides/compatibility-guide-17">Compatibility guide for Kotlin 1.7.0</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin 1.6.x section"></button><span class="nav-group-title" style="color: #999999;">Kotlin 1.6.x</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew1620.html" data-nav-id="whatsnew/whatsnew1620">Kotlin 1.6.20</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew16.html" data-nav-id="whatsnew/whatsnew16">Kotlin 1.6.0</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compatibility-guides/compatibility-guide-16.html" data-nav-id="compatibility-guides/compatibility-guide-16">Compatibility guide</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin 1.5.x section"></button><span class="nav-group-title" style="color: #999999;">Kotlin 1.5.x</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew1530.html" data-nav-id="whatsnew/whatsnew1530">Kotlin 1.5.30</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew1520.html" data-nav-id="whatsnew/whatsnew1520">Kotlin 1.5.20</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew15.html" data-nav-id="whatsnew/whatsnew15">Kotlin 1.5.0</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compatibility-guides/compatibility-guide-15.html" data-nav-id="compatibility-guides/compatibility-guide-15">Compatibility guide</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin 1.4.x section"></button><span class="nav-group-title" style="color: #999999;">Kotlin 1.4.x</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew1430.html" data-nav-id="whatsnew/whatsnew1430">Kotlin 1.4.30</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew1420.html" data-nav-id="whatsnew/whatsnew1420">Kotlin 1.4.20</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew14.html" data-nav-id="whatsnew/whatsnew14">Kotlin 1.4.0</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compatibility-guides/compatibility-guide-14.html" data-nav-id="compatibility-guides/compatibility-guide-14">Compatibility guide</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin 1.3.x section"></button><span class="nav-group-title" style="color: #999999;">Kotlin 1.3.x</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew13.html" data-nav-id="whatsnew/whatsnew13">Kotlin 1.3</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/compatibility-guides/compatibility-guide-13.html" data-nav-id="compatibility-guides/compatibility-guide-13">Compatibility guide</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew12.html" data-nav-id="whatsnew/whatsnew12">Kotlin 1.2</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/whatsnew/whatsnew11.html" data-nav-id="whatsnew/whatsnew11">Kotlin 1.1</a>
+</div>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+  <li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Early access preview (EAP) section"></button><span class="nav-group-title" style="color: #999999;">Early access preview (EAP)</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/eap.html" data-nav-id="eap">Participate</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/configure-build-for-eap.html" data-nav-id="configure-build-for-eap">Configure your build for EAP</a>
+</div>
+</li>
+</ul>
+</li>
+  <li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Learning materials section"></button><span class="nav-group-title" style="color: #999999;">Learning materials</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/learning-materials-overview.html" data-nav-id="learning-materials-overview">Overview</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Kotlin Core track</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/kotlin-hands-on.html" data-nav-id="kotlin-hands-on">Kotlin hands-on</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/kotlin-tips.html" data-nav-id="kotlin-tips">Kotlin tips</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/koans.html" data-nav-id="koans">Kotlin Koans</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/books.html" data-nav-id="books">Kotlin books</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/advent-of-code.html" data-nav-id="advent-of-code">Advent of Code puzzles</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Learn in IDE (JetBrains Academy) section"></button><span class="nav-group-title" style="color: #999999;">Learn in IDE (JetBrains Academy)</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/edu-tools-learner.html" data-nav-id="edu-tools-learner">Learn Kotlin</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/edu-tools-educator.html" data-nav-id="edu-tools-educator">Teach Kotlin</a>
+</div>
+</li>
+</ul>
+</li>
+</ul>
+</li>
+  <li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Other resources section"></button><span class="nav-group-title" style="color: #999999;">Other resources</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/faq.html" data-nav-id="faq">FAQ</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Kotlin Foundation section"></button><span class="nav-group-title" style="color: #999999;">Kotlin Foundation</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Kotlin Foundation</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Language Committee guidelines</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Submitting incompatible changes</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Brand usage</span>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Kotlin Foundation FAQ</span>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Google Summer of Code section"></button><span class="nav-group-title" style="color: #999999;">Google Summer of Code</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/gsoc-overview.html" data-nav-id="gsoc-overview">Overview</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/gsoc-2026.html" data-nav-id="gsoc-2026">GSoC 2026</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/gsoc-2025.html" data-nav-id="gsoc-2025">GSoC 2025</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/gsoc-2024.html" data-nav-id="gsoc-2024">GSoC 2024</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/gsoc-2023.html" data-nav-id="gsoc-2023">GSoC 2023</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/competitive-programming.html" data-nav-id="competitive-programming">Kotlin for competitive programming</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle Community section"></button><span class="nav-group-title" style="color: #999999;">Community</span>
+</div>
+<ul class="nav-tree nav-subtree">
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/contribute.html" data-nav-id="contribute">Contribution</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/kug-guidelines.html" data-nav-id="kug-guidelines">KUG guidelines</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/kotlin-night-guidelines.html" data-nav-id="kotlin-night-guidelines">Kotlin Night guidelines</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/slack-code-of-conduct.html" data-nav-id="slack-code-of-conduct">Code of conduct and guidelines for Kotlin Slack</a>
+</div>
+</li>
+</ul>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/kotlin-brand-assets.html" data-nav-id="kotlin-brand-assets">Kotlin brand assets</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/kotlin-pdf.html" data-nav-id="kotlin-pdf">Kotlin documentation as PDF</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/security.html" data-nav-id="security">Security</a>
+</div>
+</li>
+<li class="nav-item">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><span class="nav-group-title" style="color: #999999;">Press kit</span>
+</div>
+</li>
+<li class="nav-item nav-hidden">
+<div class="nav-row">
+<span class="nav-spacer" aria-hidden="true"></span><a class="nav-link" href="/test-page.html" data-nav-id="test-page">Testing page</a>
+</div>
+</li>
+</ul>
+</li>
+    </ul>
+</nav>
+

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/templates/nav.peb
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/templates/nav.peb
@@ -1,0 +1,50 @@
+{#
+  Renders the sidebar navigation tree built from kotlin-web-site/docs/kr.tree
+  by build_nav.py.
+
+  Expected context variable:
+    tree - a list of nav node objects (see nav.json), each shaped like:
+      {
+        "title": "Enum classes",
+        "id": "topics/enum-classes",   // null for a pure grouping header with no page of its own
+        "hidden": false,               // true for entries Writerside hides from the primary tree
+        "noLinkColor": null,           // set to config.json's "menu-no-link-color" by build_nav.py
+                                        // when this node doesn't actually lead to a generated page
+                                        // (no id at all, or a home.topic/api-references.topic style
+                                        // id that was never converted from Markdown); null otherwise
+        "children": [ ... ]            // nested nav nodes, possibly empty
+      }
+
+  `id` (when present) matches a docs-json/<id>.json file's own "id" field, so
+  href="/{{ node.id }}.html" lines up with however page.peb's output ends up
+  being served - adjust the URL prefix/extension below to match your router.
+
+  Every node with children renders a .nav-toggle-group button alongside its
+  label/link, and its <ul class="nav-subtree"> starts collapsed (see
+  assets/docs.css - collapse is a pure CSS default, not a Pebble default, so
+  it still works if this partial is ever rendered outside assets/sidebar.js's
+  reach). assets/sidebar.js handles the actual expand/collapse clicks, the
+  swipeable mobile drawer, and auto-expanding/highlighting the current page's
+  ancestor chain on load.
+#}
+<nav class="docs-nav" aria-label="Documentation">
+  <ul class="nav-tree">
+  {% for node in tree %}{{ renderNavNode(node) }}
+  {% endfor %}
+  </ul>
+</nav>
+
+{% macro renderNavNode(node) %}
+<li class="nav-item{% if node.hidden %} nav-hidden{% endif %}">
+<div class="nav-row">
+{% if node.children is not empty %}<button type="button" class="nav-toggle-group" aria-expanded="false" aria-label="Toggle {{ node.title }} section"></button>{% else %}<span class="nav-spacer" aria-hidden="true"></span>{% endif %}
+{% if node.id %}<a class="nav-link"{% if node.noLinkColor %} style="color: {{ node.noLinkColor }};"{% endif %} href="/{{ node.id }}.html" data-nav-id="{{ node.id }}">{{ node.title }}</a>
+{% else %}<span class="nav-group-title"{% if node.noLinkColor %} style="color: {{ node.noLinkColor }};"{% endif %}>{{ node.title }}</span>
+{% endif %}
+</div>
+{% if node.children is not empty %}<ul class="nav-tree nav-subtree">
+{% for child in node.children %}{{ renderNavNode(child) }}
+{% endfor %}</ul>
+{% endif %}
+</li>
+{% endmacro %}

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/templates/page.peb
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/templates/page.peb
@@ -1,0 +1,138 @@
+{#
+  Renders a single documentation page from the JSON produced by md_to_json.py.
+
+  Expected context variables (== top-level keys of one docs-json/topics/**/*.json file):
+    id         - string, e.g. "enum-classes" or "ksp/ksp-overview"
+    sourceFile - string, e.g. "topics/enum-classes.md"
+    title      - string or null
+    blocks     - list of block objects, see md_to_json.py's module docstring for the schema
+    prev, next - optional {"id": ..., "title": ...} nav neighbors (see RenderDocs.java,
+                 which derives these from nav.json's document order - the same
+                 source Writerside's own prev/next footer is built from)
+
+  Load the JSON into the model under these same names, e.g. with Jackson:
+    Map<String, Object> page = objectMapper.readValue(jsonFile, Map.class);
+    engine.getTemplate("page.peb").evaluate(writer, page);
+#}
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{% if title %}{{ title }} | {% endif %}Kotlin Docs</title>
+{% if sourceFile %}<meta name="source-file" content="{{ sourceFile }}">{% endif %}
+<link rel="stylesheet" href="/assets/docs.css">
+</head>
+<body>
+<button type="button" class="nav-toggle" id="nav-toggle" aria-label="Toggle navigation" aria-expanded="false" aria-controls="sidebar"></button>
+<div class="nav-backdrop" id="nav-backdrop"></div>
+<div class="docs-layout">
+  <aside class="docs-sidebar" id="sidebar">
+    {% include "nav.html" %}
+  </aside>
+  <main class="docs-content" id="page-{{ id }}">
+    <article>
+      {% if title %}<h1>{{ title }}</h1>{% endif %}
+      {% for block in blocks %}{{ renderBlock(block) }}
+      {% endfor %}
+    </article>
+    {% if prev is not empty or next is not empty %}
+    <nav class="docs-pager">
+      {% if prev is not empty %}<a class="docs-pager__prev" href="/{{ prev.id }}.html">{{ prev.title }}</a>{% endif %}
+      {% if next is not empty %}<a class="docs-pager__next" href="/{{ next.id }}.html">{{ next.title }}</a>{% endif %}
+    </nav>
+    {% endif %}
+  </main>
+</div>
+<script src="/assets/tabs.js" defer></script>
+<script src="/assets/sidebar.js" defer></script>
+</body>
+</html>
+
+{#
+  Recursive block renderer. Macros only see the variables passed to them, so
+  every block that can nest other blocks (blockquote, note/tip/warning, list
+  items, table cells, tabs) passes its children back through renderBlock().
+  Macros defined in a template are directly visible to themselves and to each
+  other within that same template, so no self-import is needed for recursion.
+#}
+{% macro renderBlock(b) %}
+{% if b.type == "heading" %}
+<h{{ b.level }} id="{{ b.id }}">{{ b.html|raw }}</h{{ b.level }}>
+
+{% elseif b.type == "paragraph" %}
+<p>{{ b.html|raw }}</p>
+
+{% elseif b.type == "code" %}
+<pre class="code-block"{% if b.attrs.id %} id="{{ b.attrs.id }}"{% endif %}{% if b.lang %} data-lang="{{ b.lang }}"{% endif %}{% for entry in b.attrs %}{% if entry.key != "id" %} data-{{ entry.key }}="{{ entry.value }}"{% endif %}{% endfor %}><code{% if b.lang %} class="language-{{ b.lang }}"{% endif %}>{{ b.code }}</code></pre>
+
+{% elseif b.type == "blockquote" %}
+<blockquote class="blockquote{% if b.attrs.style %} admonition {{ b.attrs.style }}{% endif %}">
+{% if b.attrs.title %}<p class="admonition-title">{{ b.attrs.title }}</p>{% endif %}
+{% for child in b.blocks %}{{ renderBlock(child) }}
+{% endfor %}</blockquote>
+
+{% elseif b.type == "note" or b.type == "tip" or b.type == "warning" %}
+<div class="admonition {{ b.type }}">
+{% if b.attrs.title %}<p class="admonition-title">{{ b.attrs.title }}</p>{% endif %}
+{% for child in b.blocks %}{{ renderBlock(child) }}
+{% endfor %}</div>
+
+{% elseif b.type == "list" %}
+{% if b.ordered %}<ol>{% else %}<ul>{% endif %}
+{% for item in b.items %}<li>{% for child in item.blocks %}{{ renderBlock(child) }}{% endfor %}</li>
+{% endfor %}{% if b.ordered %}</ol>{% else %}</ul>{% endif %}
+
+{% elseif b.type == "table" %}
+<table>
+{% if b.headers is not empty %}<thead>
+<tr>{% for h in b.headers %}<th>{{ h|raw }}</th>{% endfor %}</tr>
+</thead>{% endif %}
+<tbody>
+{% for row in b.rows %}<tr>{% for cell in row %}<td>{{ cell|raw }}</td>{% endfor %}</tr>
+{% endfor %}</tbody>
+</table>
+
+{% elseif b.type == "image" %}
+<img src="{{ b.src }}" alt="{{ b.alt|default('') }}">
+
+{% elseif b.type == "hr" %}
+<hr>
+
+{% elseif b.type == "tabs" and b.tabs is not empty %}
+{#
+  Tab switching + the group-key syncing (e.g. picking "Groovy" in one
+  Kotlin/Groovy/Maven tabs block switches every other tabs block sharing the
+  same data-group on the page, matching Writerside's data-sync-tabs
+  behavior) is implemented in assets/tabs.js. md_to_json.py's
+  _finalize_container always gives every "tabs" block a non-empty "tabs"
+  list (synthesizing one from code-block languages, or dropping the wrapper
+  entirely, when the source had no <tab> children) - the "b.tabs is not
+  empty" guard here is just a defensive backstop against any other producer
+  of this JSON schema making the same mistake, not something this pipeline
+  itself still needs.
+#}
+<div class="tabs"{% if b.attrs.group %} data-group="{{ b.attrs.group }}"{% endif %}>
+  <div class="tab-buttons" role="tablist">
+  {% for tab in b.tabs %}{% set tabKey = tab.attrs["group-key"]|default(tab.title)|default(loop.index) %}<button type="button" class="tab-button{% if loop.first %} tab-button--active{% endif %}" role="tab" aria-selected="{% if loop.first %}true{% else %}false{% endif %}" data-group-key="{{ tabKey }}">{{ tab.title }}</button>
+  {% endfor %}</div>
+  {% for tab in b.tabs %}{% set tabKey = tab.attrs["group-key"]|default(tab.title)|default(loop.index) %}<div class="tab-panel{% if loop.first %} tab-panel--active{% endif %}" role="tabpanel" data-group-key="{{ tabKey }}"{% if not loop.first %} hidden{% endif %}>
+  {% for child in tab.blocks %}{{ renderBlock(child) }}
+  {% endfor %}</div>
+  {% endfor %}
+</div>
+
+{% elseif b.type == "html" %}
+{{ b.html|raw }}
+
+{% elseif b.type == "tab" %}
+{# A lone <tab> not wrapped in <tabs> (e.g. seen in eap.json's HTML-table
+   compatibility layout); render its children rather than dropping them. #}
+{% for child in b.blocks %}{{ renderBlock(child) }}
+{% endfor %}
+
+{% else %}
+{% if b.html %}{{ b.html|raw }}{% endif %}
+
+{% endif %}
+{% endmacro %}

--- a/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/tests/test_find_missing_assets.py
+++ b/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/tests/test_find_missing_assets.py
@@ -1,0 +1,93 @@
+"""Regression test for find_missing_assets.py's exit-code behavior (PR #24
+review). find_missing_assets.py imports md_to_json.py, which doesn't exist
+on this branch yet (it lands with ADFA-5039) - so this runs the script as a
+subprocess against a minimal stand-in md_to_json module on PYTHONPATH
+instead of importing the real one.
+"""
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+STUB_MD_TO_JSON = '''
+class Converter:
+    def __init__(self, md, variables, topic_index=None, image_index=None):
+        self.warnings = []
+
+    def convert_file(self, path, page_id, source_rel):
+        if path.read_text(encoding="utf-8").strip() == "FAIL":
+            raise ValueError(f"stub failure for {path}")
+        return {"id": page_id, "sourceFile": source_rel, "blocks": []}
+
+
+def build_topic_index(topics_dir):
+    return {}
+
+
+def build_image_index(images_dir):
+    return {}, []
+
+
+def load_variables(docs_root):
+    return {}
+
+
+def make_markdown_it():
+    return None
+'''
+
+
+def _write_stub_md_to_json(tmp_path):
+    stub_dir = tmp_path / "stub"
+    stub_dir.mkdir()
+    (stub_dir / "md_to_json.py").write_text(STUB_MD_TO_JSON, encoding="utf-8")
+    return stub_dir
+
+
+def _write_minimal_docs_root(tmp_path, *, with_failure=False):
+    docs_root = tmp_path / "docs"
+    (docs_root / "topics").mkdir(parents=True)
+    (docs_root / "topics" / "good.md").write_text("# Good\n\nHello.\n", encoding="utf-8")
+    if with_failure:
+        (docs_root / "topics" / "bad.md").write_text("FAIL", encoding="utf-8")
+    return docs_root
+
+
+def _run(stub_dir, *args):
+    script = Path(__file__).resolve().parent.parent / "find_missing_assets.py"
+    env = dict(os.environ)
+    existing = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = f"{stub_dir}{os.pathsep}{existing}" if existing else str(stub_dir)
+    return subprocess.run([sys.executable, str(script), *map(str, args)], capture_output=True, text=True, env=env)
+
+
+def test_exits_zero_and_reports_zero_failures_when_nothing_fails(tmp_path):
+    stub_dir = _write_stub_md_to_json(tmp_path)
+    docs_root = _write_minimal_docs_root(tmp_path)
+    report = tmp_path / "report.md"
+    result = _run(stub_dir, docs_root, report)
+    assert result.returncode == 0
+    assert "0 file(s) failed to scan" in report.read_text(encoding="utf-8")
+
+
+def test_exits_nonzero_when_a_file_fails_to_scan(tmp_path):
+    """A per-file scan failure used to be printed to stderr and otherwise
+    ignored - the report still claimed a clean summary and the process
+    still exited 0, so a totally broken corpus was indistinguishable from a
+    clean one (this is the pre-flight gate run before populate_db.py)."""
+    stub_dir = _write_stub_md_to_json(tmp_path)
+    docs_root = _write_minimal_docs_root(tmp_path, with_failure=True)
+    report = tmp_path / "report.md"
+    result = _run(stub_dir, docs_root, report)
+    assert result.returncode == 1
+    text = report.read_text(encoding="utf-8")
+    assert "1 file(s) failed to scan" in text
+    assert "incomplete" in text.lower()
+
+
+def test_allow_failures_exits_zero_despite_failure(tmp_path):
+    stub_dir = _write_stub_md_to_json(tmp_path)
+    docs_root = _write_minimal_docs_root(tmp_path, with_failure=True)
+    report = tmp_path / "report.md"
+    result = _run(stub_dir, docs_root, report, "--allow-failures")
+    assert result.returncode == 0

--- a/ProcessDocs/ProcessKotlinDocs/run_e2e_pipeline_test.sh
+++ b/ProcessDocs/ProcessKotlinDocs/run_e2e_pipeline_test.sh
@@ -1,0 +1,220 @@
+#!/usr/bin/env bash
+# End-to-end test of the Kotlin website JSON/DB pipeline (ADFA-4737): convert
+# docs + prune blacklist into the database, re-optimize/reinsert media,
+# generate fresh kotlin-stdlib/-reflect/-test JSON docs via a freshly-built
+# kdoc-to-json plugin, then sync them into the database. Operates on a
+# scratch copy of documentation.db so the real database is never touched.
+# Re-run freely; each run recopies the source db from scratch.
+#
+# Before running: fill in every <PLACEHOLDER> value below for your machine.
+# The script refuses to start if any are left unfilled or don't exist on disk.
+set -euo pipefail
+
+# --- Repo-relative paths - auto-detected, no edits needed ---------------
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+PROCESS_DIR="$REPO_ROOT/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON"
+SYNC_SCRIPT="$REPO_ROOT/scripts/sync_kotlin_stdlib_docs/sync_kdoc_json_to_db.py"
+
+# config.json, templates/, and assets/ are staged directly in $PROCESS_DIR
+# (this repo) rather than pulled from anyone's local machine - populate_db.py
+# looks these up next to its own script location:
+#   config.json      - theming config (broken-ext-link-color, menu-no-link-color)
+#   templates/*.peb  - page.peb / nav.peb, upserted into the Templates table
+#   assets/*         - docs.css / tabs.js / sidebar.js, inserted at assets/<name>
+CONFIG_JSON="$PROCESS_DIR/config.json"
+
+# --- Machine-specific paths - fill these in --------------------------------
+
+# DOCS_ROOT: the "docs" subdirectory of a Writerside checkout of the official
+# Kotlin website. Get it from https://github.com/JetBrains/kotlin-web-site -
+# clone that repo and point this at "<checkout>/kotlin-web-site/docs" (the
+# directory directly containing kr.tree, topics/, images/, v.list).
+DOCS_ROOT="<PATH_TO_KOTLIN_WEB_SITE_DOCS_CHECKOUT>"
+
+# IMAGES_ZIP: Writerside's own image export for that same docs project (e.g.
+# "webHelpImages.zip"). Produced by running IntelliJ IDEA's Writerside plugin
+# build/export action against DOCS_ROOT's parent Writerside project; the zip
+# is written next to kr.tree once that build finishes.
+IMAGES_ZIP="<PATH_TO_WEBHELPIMAGES_ZIP>"
+
+# STDLIB_DOCS_DIR: the "libraries/tools/kotlin-stdlib-docs" directory inside
+# a full clone of https://github.com/JetBrains/kotlin (not the kotlin repo
+# root itself - this exact subdirectory). Step 4 below builds a fresh copy
+# of the kdoc-to-json plugin from this repo's Dokka-plugin-kdoc2json/ and
+# runs it against this checkout to produce kotlin-stdlib/-reflect/-test JSON
+# docs (common + jvm source sets only) - no separate manual doc-generation
+# step needed.
+STDLIB_DOCS_DIR="<PATH_TO_KOTLIN_STDLIB_DOCS_DIR>"
+
+# SOURCE_DB: the runtime "documentation.db" SQLite database this project's
+# offline documentation app/server reads from (see docdb-studio/ and
+# check-tools/ in this repo for tooling that operates on the same file). Must
+# already have its schema populated (Languages, ContentTypes, Templates
+# tables) - point this at your own working copy.
+SOURCE_DB="<PATH_TO_DOCUMENTATION_DB>"
+
+TEST_DB="$(dirname "$SOURCE_DB")/documentation.test.db"
+
+JPEG_QUALITY=85
+WEBP_QUALITY=90
+
+# Full toc-title path (top-level -> ... -> target), joined with "\/" per
+# populate_db.py's --blacklisted-element-titles convention. These are the
+# concrete cases named in ADFA-4737; add more "path" entries here to prune
+# additional sections. Re-derive these from your own DOCS_ROOT/kr.tree if the
+# site's navigation structure has changed since this was written.
+BLACKLIST=(
+  'Development\/Web development'
+  'Interoperability\/Swift/Objective-C and C interop'
+  'Interoperability\/JavaScript interop'
+)
+
+# --- Fail fast on unfilled placeholders or missing paths -------------------
+require_path() {
+  local name="$1" value="$2"
+  if [[ "$value" == "<"*">" ]]; then
+    echo "error: $name is still a placeholder ('$value') - edit this script and fill in your local path." >&2
+    exit 1
+  fi
+  if [[ ! -e "$value" ]]; then
+    echo "error: $name points to '$value', which does not exist." >&2
+    exit 1
+  fi
+}
+require_path DOCS_ROOT "$DOCS_ROOT"
+require_path IMAGES_ZIP "$IMAGES_ZIP"
+require_path STDLIB_DOCS_DIR "$STDLIB_DOCS_DIR"
+require_path SOURCE_DB "$SOURCE_DB"
+
+WORKDIR="$(mktemp -d /tmp/adfa4737-e2e.XXXXXX)"
+cleanup() { rm -rf "$WORKDIR"; }
+trap cleanup EXIT
+
+echo "== Copying $SOURCE_DB -> $TEST_DB =="
+rm -f "$TEST_DB"
+cp "$SOURCE_DB" "$TEST_DB"
+
+echo
+echo "== Step 1/5: find_missing_assets.py (source QA report) =="
+REPORT_PATH="$WORKDIR/missing-assets-report.md"
+python3 "$PROCESS_DIR/find_missing_assets.py" "$DOCS_ROOT" "$REPORT_PATH"
+echo "Report written to $REPORT_PATH"
+
+echo
+echo "== Step 2/5: populate_db.py (convert docs, prune blacklist, insert into test db) =="
+( cd "$PROCESS_DIR" && python3 populate_db.py "$DOCS_ROOT" "$CONFIG_JSON" "$IMAGES_ZIP" "$TEST_DB" \
+    --blacklisted-element-titles "${BLACKLIST[@]}" )
+
+echo
+echo "== Step 3/5: insert_optimized_media.py (re-optimize + reinsert k/html/images/*) =="
+# --webp requires an "image/webp" ContentTypes row, which this database
+# doesn't ship with (see insert_optimized_media.py's own module docstring) -
+# add it (idempotent) before running.
+sqlite3 "$TEST_DB" "INSERT OR IGNORE INTO ContentTypes (value, compression) VALUES ('image/webp', 'brotli');"
+
+# insert_optimized_media.py addresses images by bare filename, matching
+# populate_db.py's own flat k/html/images/<name> convention - so its input
+# media_dir needs to be a directory of files with those same basenames.
+# The images actually inserted above came from IMAGES_ZIP, so extract that
+# same zip here rather than pointing at DOCS_ROOT/images (the raw, unoptimized
+# Writerside source tree - a different, much larger set of files).
+MEDIA_DIR="$WORKDIR/media"
+mkdir -p "$MEDIA_DIR"
+unzip -q "$IMAGES_ZIP" -d "$MEDIA_DIR"
+
+python3 "$PROCESS_DIR/insert_optimized_media.py" "$MEDIA_DIR" "$TEST_DB" \
+    --jpeg-quality "$JPEG_QUALITY" --webp --webp-quality "$WEBP_QUALITY" --verbose
+
+echo
+echo "== Step 4/5: build-stdlib-json-docs.sh (fresh plugin build -> kotlin-stdlib/-reflect/-test JSON) =="
+# STDLIB_DOCS_DIR is .../kotlin/libraries/tools/kotlin-stdlib-docs; the
+# kotlin repo root (needed to locate gradle/libs.versions.toml and to
+# resolve kotlin_root inside the injected build.gradle.kts) is exactly three
+# levels up, matching that build.gradle.kts's own "../../../" convention.
+KOTLIN_ROOT="$(cd "$STDLIB_DOCS_DIR/../../.." && pwd)"
+STDLIB_ALL_LIBS="$("$REPO_ROOT/Dokka-plugin-kdoc2json/scripts/kotlin/build-stdlib-json-docs.sh" \
+    "$KOTLIN_ROOT" "$WORKDIR/stdlib-json")"
+echo "Generated JSON docs at $STDLIB_ALL_LIBS"
+
+echo
+echo "== Step 5/5: sync_kdoc_json_to_db.py (overwrite kotlin-stdlib/-reflect/-test content) =="
+python3 "$SYNC_SCRIPT" "$STDLIB_ALL_LIBS" --db "$TEST_DB"
+
+echo
+echo "== Summary =="
+python3 - "$TEST_DB" <<'PYEOF'
+import sqlite3
+import sys
+
+db_path = sys.argv[1]
+conn = sqlite3.connect(db_path)
+
+
+def count(where, params=()):
+    return conn.execute(f"SELECT count(*) FROM Content WHERE {where}", params).fetchone()[0]
+
+
+print(f"Database: {db_path}")
+print(f"  k/html/*        rows: {count('path LIKE ?', ('k/html/%',))}")
+print(f"  k/html/images/* rows: {count('path LIKE ?', ('k/html/images/%',))}")
+print(f"  k/html/images/*.webp rows: {count('path LIKE ?', ('k/html/images/%.webp%',))}")
+print(f"  k/kotlin-stdlib/*  rows: {count('path LIKE ? OR path = ?', ('k/kotlin-stdlib/%', 'k/kotlin-stdlib'))}")
+print(f"  k/kotlin-reflect/* rows: {count('path LIKE ? OR path = ?', ('k/kotlin-reflect/%', 'k/kotlin-reflect'))}")
+print(f"  k/kotlin-test/*    rows: {count('path LIKE ? OR path = ?', ('k/kotlin-test/%', 'k/kotlin-test'))}")
+
+conn.close()
+PYEOF
+
+echo
+echo "== Blacklist pruning verification =="
+# Recomputes, from the same kr.tree and BLACKLIST used above, exactly which
+# topic stems populate_db.py's own prune_blacklisted_elements() decided to
+# exclude - then confirms none of those pages made it into the database.
+# Reusing that real pruning logic (rather than guessing at path patterns)
+# means this check stays correct if BLACKLIST or kr.tree's structure change.
+python3 - "$PROCESS_DIR" "$DOCS_ROOT" "$TEST_DB" "${BLACKLIST[@]}" <<'PYEOF'
+import sqlite3
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+process_dir, docs_root, db_path, *blacklist_raw = sys.argv[1:]
+sys.path.insert(0, process_dir)
+import populate_db  # noqa: E402
+
+root = ET.parse(Path(docs_root) / "kr.tree").getroot()
+blacklisted_paths = {populate_db.parse_blacklist_path(raw) for raw in blacklist_raw}
+blacklisted_stems, unmatched_paths = populate_db.prune_blacklisted_elements(root, blacklisted_paths)
+
+conn = sqlite3.connect(db_path)
+leftover = []
+for stem in sorted(blacklisted_stems):
+    path = f"k/html/{stem}.html"
+    if conn.execute("SELECT 1 FROM Content WHERE path = ?", (path,)).fetchone():
+        leftover.append(path)
+conn.close()
+
+print(f"Blacklisted toc-element path(s) checked: {len(blacklisted_paths)}")
+for path in sorted(blacklisted_paths):
+    status = "unmatched (no such element in kr.tree)" if path in unmatched_paths else "matched"
+    print(f"  {' > '.join(path)}: {status}")
+print(f"Topic page(s) expected removed: {len(blacklisted_stems)}")
+
+if unmatched_paths:
+    print(f"FAIL: {len(unmatched_paths)} blacklist path(s) never matched a <toc-element> - "
+          "check BLACKLIST against this DOCS_ROOT's kr.tree.")
+    sys.exit(1)
+if leftover:
+    print(f"FAIL: {len(leftover)} blacklisted page(s) still present in the database:")
+    for path in leftover:
+        print(f"  {path}")
+    sys.exit(1)
+
+print(f"PASS: all {len(blacklisted_stems)} blacklisted topic page(s) confirmed absent from {db_path}.")
+PYEOF
+
+echo
+echo "Done. Backups (populate_db.py, insert_optimized_media.py, and sync_kdoc_json_to_db.py"
+echo "each make their own) live alongside $TEST_DB as documentation.test.db.backup-* and"
+echo "documentation.test.db.bak.*"
+echo "The real database at $SOURCE_DB was never opened for writing."

--- a/ProcessDocs/ProcessKotlinDocs/run_e2e_pipeline_test.sh
+++ b/ProcessDocs/ProcessKotlinDocs/run_e2e_pipeline_test.sh
@@ -10,10 +10,16 @@
 # The script refuses to start if any are left unfilled or don't exist on disk.
 set -euo pipefail
 
+if ! command -v uv >/dev/null 2>&1; then
+  echo "error: uv is required - see https://docs.astral.sh/uv/getting-started/installation/" >&2
+  exit 1
+fi
+
 # --- Repo-relative paths - auto-detected, no edits needed ---------------
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 PROCESS_DIR="$REPO_ROOT/ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON"
 SYNC_SCRIPT="$REPO_ROOT/scripts/sync_kotlin_stdlib_docs/sync_kdoc_json_to_db.py"
+UV_RUN=(uv run --with-requirements "$REPO_ROOT/requirements.txt")
 
 # config.json, templates/, and assets/ are staged directly in $PROCESS_DIR
 # (this repo) rather than pulled from anyone's local machine - populate_db.py
@@ -97,12 +103,12 @@ cp "$SOURCE_DB" "$TEST_DB"
 echo
 echo "== Step 1/5: find_missing_assets.py (source QA report) =="
 REPORT_PATH="$WORKDIR/missing-assets-report.md"
-python3 "$PROCESS_DIR/find_missing_assets.py" "$DOCS_ROOT" "$REPORT_PATH"
+"${UV_RUN[@]}" "$PROCESS_DIR/find_missing_assets.py" "$DOCS_ROOT" "$REPORT_PATH"
 echo "Report written to $REPORT_PATH"
 
 echo
 echo "== Step 2/5: populate_db.py (convert docs, prune blacklist, insert into test db) =="
-( cd "$PROCESS_DIR" && python3 populate_db.py "$DOCS_ROOT" "$CONFIG_JSON" "$IMAGES_ZIP" "$TEST_DB" \
+( cd "$PROCESS_DIR" && "${UV_RUN[@]}" populate_db.py "$DOCS_ROOT" "$CONFIG_JSON" "$IMAGES_ZIP" "$TEST_DB" \
     --blacklisted-element-titles "${BLACKLIST[@]}" )
 
 echo
@@ -122,7 +128,7 @@ MEDIA_DIR="$WORKDIR/media"
 mkdir -p "$MEDIA_DIR"
 unzip -q "$IMAGES_ZIP" -d "$MEDIA_DIR"
 
-python3 "$PROCESS_DIR/insert_optimized_media.py" "$MEDIA_DIR" "$TEST_DB" \
+"${UV_RUN[@]}" "$PROCESS_DIR/insert_optimized_media.py" "$MEDIA_DIR" "$TEST_DB" \
     --jpeg-quality "$JPEG_QUALITY" --webp --webp-quality "$WEBP_QUALITY" --verbose
 
 echo
@@ -138,11 +144,11 @@ echo "Generated JSON docs at $STDLIB_ALL_LIBS"
 
 echo
 echo "== Step 5/5: sync_kdoc_json_to_db.py (overwrite kotlin-stdlib/-reflect/-test content) =="
-python3 "$SYNC_SCRIPT" "$STDLIB_ALL_LIBS" --db "$TEST_DB"
+"${UV_RUN[@]}" "$SYNC_SCRIPT" "$STDLIB_ALL_LIBS" --db "$TEST_DB"
 
 echo
 echo "== Summary =="
-python3 - "$TEST_DB" <<'PYEOF'
+"${UV_RUN[@]}" python3 - "$TEST_DB" <<'PYEOF'
 import sqlite3
 import sys
 
@@ -172,7 +178,7 @@ echo "== Blacklist pruning verification =="
 # exclude - then confirms none of those pages made it into the database.
 # Reusing that real pruning logic (rather than guessing at path patterns)
 # means this check stays correct if BLACKLIST or kr.tree's structure change.
-python3 - "$PROCESS_DIR" "$DOCS_ROOT" "$TEST_DB" "${BLACKLIST[@]}" <<'PYEOF'
+"${UV_RUN[@]}" python3 - "$PROCESS_DIR" "$DOCS_ROOT" "$TEST_DB" "${BLACKLIST[@]}" <<'PYEOF'
 import sqlite3
 import sys
 import xml.etree.ElementTree as ET

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ brotli
 Pillow
 openpyxl>=3.1.0
 tqdm-loggable>=0.1.0
+scour
+cairosvg

--- a/scripts/sync_kotlin_stdlib_docs/sync_kdoc_json_to_db.py
+++ b/scripts/sync_kotlin_stdlib_docs/sync_kdoc_json_to_db.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""
+Overwrites the kotlin-stdlib / kotlin-reflect / kotlin-test Content rows in
+documentation.db with fresh output from the KDoc-to-JSON Dokka plugin.
+
+For every existing Content row whose path starts with "k/kotlin-stdlib",
+"k/kotlin-reflect", or "k/kotlin-test":
+  - Compute the corresponding file in the plugin output tree: strip the "k/"
+    prefix, and if the path ends in ".html", swap that for ".json" (paths with
+    no extension, e.g. ".../package-list", are looked up unchanged).
+  - If that file exists, re-compress it (matching the row's existing
+    ContentTypes.compression) and overwrite the row's `content` blob only --
+    `path`, `languageID`, `contentTypeID`, and `templateId` are left untouched.
+  - If it doesn't exist, delete the row.
+
+Any TooltipButtons row whose `uri` (ignoring a trailing "#fragment") matches one
+of the deleted Content paths is now a dead link. Its entire parent Tooltips
+record -- along with all of that tooltip's other TooltipButtons rows, dead or
+not -- is deleted too, since TooltipButtons has no ON DELETE CASCADE and a
+dangling tooltipId would otherwise be left behind.
+
+A timestamped backup of the database is made before anything is modified.
+"""
+import argparse
+import os
+import shutil
+import sqlite3
+import sys
+from datetime import datetime, timezone
+
+import brotli
+
+PREFIXES = ["k/kotlin-stdlib", "k/kotlin-reflect", "k/kotlin-test"]
+
+
+def backup_database(db_path):
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup_path = f"{db_path}.bak.{timestamp}"
+    shutil.copy2(db_path, backup_path)
+    return backup_path
+
+
+def relative_target_path(content_path):
+    """'k/kotlin-stdlib/kotlin.text/index.html' -> 'kotlin-stdlib/kotlin.text/index.json'
+    'k/kotlin-stdlib/package-list' -> 'kotlin-stdlib/package-list' (no extension to swap)"""
+    without_prefix = content_path[len("k/"):]
+    if without_prefix.endswith(".html"):
+        return without_prefix[: -len(".html")] + ".json"
+    return without_prefix
+
+
+def compress_for(compression, raw_bytes, path):
+    if compression == "brotli":
+        return brotli.compress(raw_bytes)
+    if compression == "none":
+        return raw_bytes
+    raise ValueError(f"Unknown compression '{compression}' needed for {path}")
+
+
+def cleanup_orphaned_tooltips(cur, deleted_paths, dry_run):
+    """Delete any Tooltips (and all their TooltipButtons) that reference a
+    now-deleted Content path via a TooltipButtons.uri. Returns (tooltips_removed,
+    buttons_removed)."""
+    if not deleted_paths:
+        return 0, 0
+
+    deleted_path_set = set(deleted_paths)
+
+    where_clause = " OR ".join(["uri = ? OR uri LIKE ?"] * len(PREFIXES))
+    params = []
+    for prefix in PREFIXES:
+        params.extend([prefix, prefix + "/%"])
+
+    candidate_buttons = cur.execute(
+        f"SELECT tooltipId, uri FROM TooltipButtons WHERE {where_clause}", params
+    ).fetchall()
+
+    orphaned_tooltip_ids = sorted(
+        {tooltip_id for tooltip_id, uri in candidate_buttons if uri.split("#", 1)[0] in deleted_path_set}
+    )
+    if not orphaned_tooltip_ids:
+        return 0, 0
+
+    placeholders = ",".join("?" * len(orphaned_tooltip_ids))
+    buttons_count = cur.execute(
+        f"SELECT count(*) FROM TooltipButtons WHERE tooltipId IN ({placeholders})", orphaned_tooltip_ids
+    ).fetchone()[0]
+
+    if dry_run:
+        for tooltip_id in orphaned_tooltip_ids:
+            print(f"  [DELETE TOOLTIP] id={tooltip_id}")
+    else:
+        cur.execute(f"DELETE FROM TooltipButtons WHERE tooltipId IN ({placeholders})", orphaned_tooltip_ids)
+        cur.execute(f"DELETE FROM Tooltips WHERE id IN ({placeholders})", orphaned_tooltip_ids)
+
+    return len(orphaned_tooltip_ids), buttons_count
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument(
+        "plugin_output_root",
+        help="Root dir directly containing kotlin-stdlib/, kotlin-reflect/, kotlin-test/ "
+             "(e.g. .../all-libs from a KDoc-to-JSON run)",
+    )
+    parser.add_argument("--db", default="documentation.db", help="Path to documentation.db (default: documentation.db in the current directory)")
+    parser.add_argument("--dry-run", action="store_true", help="Report what would happen without modifying anything")
+    args = parser.parse_args()
+
+    if not os.path.isdir(args.plugin_output_root):
+        print(f"Error: '{args.plugin_output_root}' is not a directory.", file=sys.stderr)
+        sys.exit(2)
+    if not os.path.isfile(args.db):
+        print(f"Error: database '{args.db}' not found.", file=sys.stderr)
+        sys.exit(2)
+
+    if args.dry_run:
+        print("Dry run: no backup will be made and no changes will be written.")
+    else:
+        backup_path = backup_database(args.db)
+        print(f"Backed up database to: {backup_path}")
+
+    conn = sqlite3.connect(args.db)
+    cur = conn.cursor()
+
+    compression_by_type = dict(cur.execute("SELECT id, compression FROM ContentTypes"))
+
+    where_clause = " OR ".join(["path = ? OR path LIKE ?"] * len(PREFIXES))
+    params = []
+    for prefix in PREFIXES:
+        params.extend([prefix, prefix + "/%"])
+
+    rows = cur.execute(
+        f"SELECT id, path, contentTypeID FROM Content WHERE {where_clause}", params
+    ).fetchall()
+
+    print(f"Found {len(rows)} existing Content record(s) under {PREFIXES}.")
+
+    updated = 0
+    deleted = 0
+    deleted_paths = []
+    unknown_types = set()
+
+    try:
+        conn.execute("BEGIN")
+        for content_id, path, content_type_id in rows:
+            rel_target = relative_target_path(path)
+            source_file = os.path.join(args.plugin_output_root, rel_target)
+
+            if os.path.isfile(source_file):
+                with open(source_file, "rb") as f:
+                    raw_bytes = f.read()
+
+                compression = compression_by_type.get(content_type_id)
+                if compression is None:
+                    unknown_types.add(content_type_id)
+                    compression = "none"
+
+                new_blob = compress_for(compression, raw_bytes, path)
+
+                if args.dry_run:
+                    print(f"  [UPDATE] {path}  <-  {rel_target}")
+                else:
+                    cur.execute("UPDATE Content SET content = ? WHERE id = ?", (new_blob, content_id))
+                updated += 1
+            else:
+                if args.dry_run:
+                    print(f"  [DELETE] {path}  (no matching {rel_target})")
+                else:
+                    cur.execute("DELETE FROM Content WHERE id = ?", (content_id,))
+                deleted += 1
+                deleted_paths.append(path)
+
+        tooltips_removed, buttons_removed = cleanup_orphaned_tooltips(cur, deleted_paths, args.dry_run)
+
+        if unknown_types:
+            print(
+                f"WARNING: contentTypeID(s) {sorted(unknown_types)} not found in ContentTypes; "
+                "treated as uncompressed.",
+                file=sys.stderr,
+            )
+
+        if args.dry_run:
+            conn.rollback()
+            print(
+                f"\nDry run complete: would update {updated}, delete {deleted} Content record(s); "
+                f"would delete {tooltips_removed} Tooltips record(s) ({buttons_removed} TooltipButtons "
+                "row(s)). No changes made."
+            )
+        else:
+            conn.commit()
+            print(
+                f"\nDone: updated {updated}, deleted {deleted} Content record(s); "
+                f"deleted {tooltips_removed} Tooltips record(s) ({buttons_removed} TooltipButtons row(s))."
+            )
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
An end-to-end pipeline for loading Kotlin website content and
kotlin-stdlib/-reflect/-test JSON docs into `documentation.db`, plus a
GitHub Action (`Build Kotlin Docs`) that runs it against a Drive-hosted copy
of the database.

## Scope
Split out of [#21](https://github.com/appdevforall/OfflineDocumentationTools/pull/21)
into two ticket-scoped PRs:
- [ADFA-5039](https://github.com/appdevforall/OfflineDocumentationTools/pull/23) - producing the raw JSON data for the Kotlin website (`md_to_json.py`).
- **ADFA-4739 (this PR)** - the database-manipulation side and the GitHub Action.

**This PR depends on ADFA-5039 merging first.** `populate_db.py`,
`build_nav.py`, and `find_missing_assets.py` all `import` `md_to_json.py`
directly, and that file isn't included here. Please review this PR's
content, but hold off merging until #23 lands - `README.md` in particular
will very likely conflict with #23's own new `README.md` at the same path
(both add a new file there) and need a quick manual merge to combine the two
once both are in.

## Changes
- `ProcessDocs/ProcessKotlinDocs/ProcessKotlinWebsiteJSON/`: `build_nav.py`
  (sidebar nav from `kr.tree`), `find_missing_assets.py` (source QA),
  `populate_db.py` (inserts pages/nav/media into `documentation.db`,
  supports pruning via `--blacklisted-element-titles`), `optimize_media.py`
  / `insert_optimized_media.py` (media optimization + DB update),
  `templates/`, `assets/`.
- `scripts/sync_kotlin_stdlib_docs/sync_kdoc_json_to_db.py` - syncs
  Dokka-generated kotlin-stdlib/-reflect/-test JSON into the database.
- `ProcessDocs/ProcessKotlinDocs/run_e2e_pipeline_test.sh` - local e2e test
  of the whole pipeline against a scratch copy of the database.
- `.github/workflows/build-kotlin-docs.yaml` - CI counterpart: pulls
  `documentation.db` (and Writerside's `webHelpImages.zip`) from Google
  Drive, runs the same pipeline, uploads the result back.
- `Dokka-plugin-kdoc2json/scripts/kotlin/build-stdlib-json-docs.sh` +
  `build.gradle.kts` tweak - builds the kdoc-to-json plugin and generates
  the stdlib JSON docs the sync script consumes.
- `CLAUDE.md` - repo-level orientation doc (schema drift between this repo's
  tooling and the live production database, repo tour, decisions log).

## Test plan
- [ ] Once ADFA-5039 is merged and this branch is rebased, re-run
  `run_e2e_pipeline_test.sh` locally against a scratch database.
- [ ] Trigger `Build Kotlin Docs` with `dry_run: true` and confirm the
  summary/blacklist-verification steps pass.
- [ ] Reviewer confirms the scripts match their originals in #21 (no edits
  made during the split, aside from `README.md` being trimmed to drop the
  `md_to_json.py`-only section now covered by ADFA-5039).

[ADFA-5039]: https://appdevforall.atlassian.net/browse/ADFA-5039?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ